### PR TITLE
Add Crosvm PCI hotplug support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # vhotplug
 
+## Crosvm PCI Requirements
+
+Crosvm PCI passthrough requires a build that accepts `removable=true` in
+`--vfio` options and implements `crosvm vfio list SOCKET`. The list command
+must report the host sysfs paths of both cold- and runtime-attached VFIO
+devices. Vhotplug probes the live list interface before changing host driver
+ownership.
+
 This application runs as a service on the host, monitors device add/remove events using libudev and dynamically attaches devices to virtual machines based on rules defined in a configuration file.
 
 # Features

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -94,6 +94,9 @@ in
         );
         Restart = "on-failure";
         RestartSec = "5s";
+        StateDirectory = "vhotplug";
+        StateDirectoryMode = "0700";
+        UMask = "0077";
       };
     };
   };

--- a/nix/nixos-test.nix
+++ b/nix/nixos-test.nix
@@ -48,6 +48,8 @@ pkgs.testers.runNixOSTest {
     machine.start()
     machine.wait_for_unit("vhotplug.service")
     machine.succeed("systemctl status vhotplug.service")
+    machine.succeed("test $(stat -c %a /var/lib/vhotplug) = 700")
+    machine.succeed("test $(systemctl show -P UMask vhotplug.service) = 0077")
 
     # Verify vhotplug is waiting for devices
     machine.wait_until_succeeds("journalctl -u vhotplug.service | grep -q 'Waiting for new devices'")

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -22,7 +22,9 @@ python3Packages.buildPythonApplication {
     qemu-qmp
   ];
 
-  doCheck = false;
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+  ];
 
   meta = with lib; {
     description = "Hot-plugging USB and PCI devices to virtual machines";

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any, cast
+
+import pytest
+
+from vhotplugcli.apiclient import APIClient
+from vhotplugcli.vhotplugcli import vmm_args
+
+
+class FakeClient:
+    def __init__(self, response: dict[str, Any] | None = None, error: RuntimeError | None = None) -> None:
+        self.response = response
+        self.error = error
+        self.require_pci: bool | None = None
+
+    def connect(self) -> None:
+        if self.error is not None:
+            raise self.error
+
+    def vmm_args(
+        self,
+        _vm: str,
+        _qemu_bus_prefix: str | None,
+        _qemu_bus_start_index: int | None,
+        require_pci: bool,
+    ) -> dict[str, Any]:
+        self.require_pci = require_pci
+        assert self.response is not None
+        return self.response
+
+
+def test_vmm_args_forwards_required_pci(capsys: pytest.CaptureFixture[str]) -> None:
+    client = FakeClient({"result": "ok", "vmm_args": ["--vfio", "/sys/device"]})
+
+    vmm_args(cast(APIClient, client), "net-vm", None, 1, timeout=0, require_pci=True)
+
+    assert client.require_pci is True
+    assert capsys.readouterr().out == "--vfio /sys/device"
+
+
+def test_vmm_args_connection_timeout() -> None:
+    client = FakeClient(error=RuntimeError("daemon unavailable"))
+
+    with pytest.raises(RuntimeError, match="Timed out waiting for vhotplug"):
+        vmm_args(cast(APIClient, client), "net-vm", None, 1, timeout=0, require_pci=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,3 +45,10 @@ def test_vmm_args_connection_timeout() -> None:
 
     with pytest.raises(RuntimeError, match="Timed out waiting for vhotplug"):
         vmm_args(cast(APIClient, client), "net-vm", None, 1, timeout=0, require_pci=True)
+
+
+def test_vmm_args_rejects_whitespace() -> None:
+    client = FakeClient({"result": "ok", "vmm_args": ["--vfio", "/sys/device with-space"]})
+
+    with pytest.raises(RuntimeError, match="arguments containing whitespace"):
+        vmm_args(cast(APIClient, client), "net-vm", None, 1, timeout=0, require_pci=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -272,6 +272,28 @@ def test_pci_rule_qemu_use_root_bus(tmp_path: Path) -> None:
     assert res is not None and res.qemu_use_root_bus
 
 
+def test_pci_rule_crosvm_use_root_bus(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "pciPassthrough": [
+                    {
+                        "description": "Integrated GPU for VM1",
+                        "targetVm": "vm1",
+                        "crosvmUseRootBus": True,
+                        "allow": [{"vendorId": "8086", "deviceId": "7d45"}],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    config = Config(str(config_path))
+    res = config.vm_for_device(PCIInfo(address="0000:00:02.0", vendor_id=0x8086, device_id=0x7D45))
+    assert res is not None and res.crosvm_use_root_bus
+
+
 def test_usb_authorization(tmp_path: Path) -> None:
     config = Config("config.json")
     assert not config.usb_authorization_enabled()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,13 @@ def test_input() -> None:
     assert res is not None and res.target_vm == "vm1" and res.allowed_vms is None
 
 
+def test_pci_passthrough_rule_targets_vm() -> None:
+    config = Config("config.json")
+
+    assert config.has_pci_passthrough_for_vm("vm1")
+    assert not config.has_pci_passthrough_for_vm("vm2")
+
+
 def test_input_ignore_vid_pid() -> None:
     config = Config("config.json")
     res = config.vm_for_device(

--- a/tests/test_crosvmlink.py
+++ b/tests/test_crosvmlink.py
@@ -9,12 +9,15 @@ from vhotplug.usb import USBInfo
 
 
 class FakeProcess:
-    def __init__(self, stdout: str, returncode: int = 0) -> None:
+    def __init__(self, stdout: str | bytes, returncode: int = 0, stderr: str | bytes = "") -> None:
         self.stdout = stdout
+        self.stderr = stderr
         self.returncode = returncode
 
     async def communicate(self) -> tuple[bytes, bytes]:
-        return self.stdout.encode(), b""
+        stdout = self.stdout.encode() if isinstance(self.stdout, str) else self.stdout
+        stderr = self.stderr.encode() if isinstance(self.stderr, str) else self.stderr
+        return stdout, stderr
 
 
 def fake_crosvm(
@@ -179,6 +182,33 @@ def test_pci_add_reconciles_against_crosvm_list(monkeypatch: pytest.MonkeyPatch)
     assert len([command for command in calls if command[1:3] == ("vfio", "add")]) == 1
 
 
+def test_pci_add_is_not_reissued_while_waiting_for_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, ...]] = []
+    add_accepted = False
+    lists_after_add = 0
+    path = "/sys/bus/pci/devices/0000:00:1f.3"
+
+    async def execute(*args: str, **_kwargs: Any) -> FakeProcess:
+        nonlocal add_accepted, lists_after_add
+        calls.append(args)
+        if args[1:3] == ("vfio", "add"):
+            add_accepted = True
+            return FakeProcess("")
+        if args[1:3] == ("vfio", "list"):
+            if add_accepted:
+                lists_after_add += 1
+            return FakeProcess(f"devices {path}" if lists_after_add >= 2 else "devices")
+        raise AssertionError(f"Unexpected Crosvm command: {args}")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", execute)
+    crosvm = link(monkeypatch)
+    crosvm.vm_retry_timeout = 0
+
+    asyncio.run(crosvm.add_pci_device(pci()))
+
+    assert len([command for command in calls if command[1:3] == ("vfio", "add")]) == 1
+
+
 def test_pci_remove_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
     calls, attached = fake_crosvm_vfio(monkeypatch)
     path = "/sys/bus/pci/devices/0000:00:1f.3"
@@ -189,6 +219,33 @@ def test_pci_remove_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
     asyncio.run(crosvm.remove_pci_device(pci()))
 
     assert not attached
+    assert len([command for command in calls if command[1:3] == ("vfio", "remove")]) == 1
+
+
+def test_pci_remove_is_not_reissued_while_waiting_for_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, ...]] = []
+    remove_accepted = False
+    lists_after_remove = 0
+    path = "/sys/bus/pci/devices/0000:00:1f.3"
+
+    async def execute(*args: str, **_kwargs: Any) -> FakeProcess:
+        nonlocal remove_accepted, lists_after_remove
+        calls.append(args)
+        if args[1:3] == ("vfio", "remove"):
+            remove_accepted = True
+            return FakeProcess("")
+        if args[1:3] == ("vfio", "list"):
+            if remove_accepted:
+                lists_after_remove += 1
+            return FakeProcess("devices" if lists_after_remove >= 2 else f"devices {path}")
+        raise AssertionError(f"Unexpected Crosvm command: {args}")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", execute)
+    crosvm = link(monkeypatch)
+    crosvm.vm_retry_timeout = 0
+
+    asyncio.run(crosvm.remove_pci_device(pci()))
+
     assert len([command for command in calls if command[1:3] == ("vfio", "remove")]) == 1
 
 
@@ -246,3 +303,63 @@ def test_pci_list_rejects_failed_command(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(asyncio, "create_subprocess_exec", execute)
     with pytest.raises(RuntimeError, match="VFIO list failed"):
         asyncio.run(link(monkeypatch).pci_list())
+
+
+def test_pci_list_rejects_unexpected_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def execute(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return FakeProcess("devices none attached")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", execute)
+    with pytest.raises(RuntimeError, match="Unexpected entries"):
+        asyncio.run(link(monkeypatch).pci_list())
+
+
+def test_vfio_failure_reports_stdout_and_replaces_invalid_utf8(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def execute(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return FakeProcess(b"\xffdevice busy", returncode=1)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", execute)
+    with pytest.raises(RuntimeError, match=r"app-vm\.sock.*device busy"):
+        asyncio.run(link(monkeypatch).pci_list())
+
+
+def test_wait_until_pci_removed_times_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    _calls, attached = fake_crosvm_vfio(monkeypatch)
+    attached.add("/sys/bus/pci/devices/0000:00:1f.3")
+    crosvm = link(monkeypatch)
+    crosvm.vm_retry_count = 0
+
+    with pytest.raises(RuntimeError, match="Timed out waiting"):
+        asyncio.run(crosvm.wait_until_pci_removed(pci()))
+
+
+def test_vfio_command_timeout_terminates_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    class HangingProcess:
+        returncode = None
+
+        def __init__(self) -> None:
+            self.killed = False
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+        def kill(self) -> None:
+            self.killed = True
+
+        async def wait(self) -> int:
+            return 1
+
+    process = HangingProcess()
+
+    async def execute(*_args: str, **_kwargs: Any) -> HangingProcess:
+        return process
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", execute)
+    crosvm = link(monkeypatch)
+    crosvm.vfio_command_timeout = 0.01
+
+    with pytest.raises(RuntimeError, match="VFIO list timed out"):
+        asyncio.run(crosvm.pci_list())
+
+    assert process.killed

--- a/tests/test_crosvmlink.py
+++ b/tests/test_crosvmlink.py
@@ -1,9 +1,10 @@
 import asyncio
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
 from vhotplug.crosvmlink import CrosvmLink, CrosvmVMUnavailableError
+from vhotplug.pci import PCIInfo
 from vhotplug.usb import USBInfo
 
 
@@ -136,3 +137,112 @@ def test_no_available_port_does_not_detach_other_devices(monkeypatch: pytest.Mon
         asyncio.run(crosvm.add_usb_device(usb()))
 
     assert not any(command[1:3] == ("usb", "detach") for command in calls)
+
+
+def pci() -> PCIInfo:
+    return PCIInfo(address="0000:00:1f.3")
+
+
+def fake_crosvm_vfio(monkeypatch: pytest.MonkeyPatch) -> tuple[list[tuple[str, ...]], set[str]]:
+    calls: list[tuple[str, ...]] = []
+    attached: set[str] = set()
+
+    async def execute(*args: str, **_kwargs: Any) -> FakeProcess:
+        calls.append(args)
+        command = args[2]
+        if command == "list":
+            return FakeProcess("devices" + "".join(f" {path}" for path in sorted(attached)))
+        path = args[3]
+        if command == "add":
+            attached.add(path)
+        elif command == "remove":
+            attached.discard(path)
+        else:
+            raise AssertionError(f"Unexpected Crosvm command: {args}")
+        # Successful add/remove commands do not print a response; callers
+        # verify completion with the subsequent list command.
+        return FakeProcess("")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", execute)
+    return calls, attached
+
+
+def test_pci_add_reconciles_against_crosvm_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls, attached = fake_crosvm_vfio(monkeypatch)
+    crosvm = link(monkeypatch)
+
+    asyncio.run(crosvm.add_pci_device(pci()))
+    asyncio.run(crosvm.add_pci_device(pci()))
+
+    path = "/sys/bus/pci/devices/0000:00:1f.3"
+    assert attached == {path}
+    assert len([command for command in calls if command[1:3] == ("vfio", "add")]) == 1
+
+
+def test_pci_remove_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls, attached = fake_crosvm_vfio(monkeypatch)
+    path = "/sys/bus/pci/devices/0000:00:1f.3"
+    attached.add(path)
+    crosvm = link(monkeypatch)
+
+    asyncio.run(crosvm.remove_pci_device(pci()))
+    asyncio.run(crosvm.remove_pci_device(pci()))
+
+    assert not attached
+    assert len([command for command in calls if command[1:3] == ("vfio", "remove")]) == 1
+
+
+def test_pci_add_retries_transient_list_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls, attached = fake_crosvm_vfio(monkeypatch)
+    original_execute: Any = asyncio.create_subprocess_exec
+    failures = 1
+
+    async def execute(*args: str, **kwargs: Any) -> FakeProcess:
+        nonlocal failures
+        if args[1:3] == ("vfio", "list") and failures:
+            failures -= 1
+            return FakeProcess("", returncode=1)
+        return cast(FakeProcess, await original_execute(*args, **kwargs))
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", execute)
+    crosvm = link(monkeypatch)
+    crosvm.vm_retry_timeout = 0
+
+    asyncio.run(crosvm.add_pci_device(pci()))
+
+    assert attached == {"/sys/bus/pci/devices/0000:00:1f.3"}
+    assert len([command for command in calls if command[1:3] == ("vfio", "add")]) == 1
+
+
+def test_pci_remove_retries_failed_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls, attached = fake_crosvm_vfio(monkeypatch)
+    original_execute: Any = asyncio.create_subprocess_exec
+    path = "/sys/bus/pci/devices/0000:00:1f.3"
+    attached.add(path)
+    failures = 1
+
+    async def execute(*args: str, **kwargs: Any) -> FakeProcess:
+        nonlocal failures
+        if args[1:3] == ("vfio", "remove") and failures:
+            calls.append(args)
+            failures -= 1
+            return FakeProcess("", returncode=1)
+        return cast(FakeProcess, await original_execute(*args, **kwargs))
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", execute)
+    crosvm = link(monkeypatch)
+    crosvm.vm_retry_timeout = 0
+
+    asyncio.run(crosvm.remove_pci_device(pci()))
+
+    assert not attached
+    assert len([command for command in calls if command[1:3] == ("vfio", "remove")]) == 2
+
+
+def test_pci_list_rejects_failed_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def execute(*_args: str, **_kwargs: Any) -> FakeProcess:
+        return FakeProcess("", returncode=1)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", execute)
+    with pytest.raises(RuntimeError, match="VFIO list failed"):
+        asyncio.run(link(monkeypatch).pci_list())

--- a/tests/test_crosvmlink.py
+++ b/tests/test_crosvmlink.py
@@ -1,0 +1,138 @@
+import asyncio
+from typing import Any
+
+import pytest
+
+from vhotplug.crosvmlink import CrosvmLink, CrosvmVMUnavailableError
+from vhotplug.usb import USBInfo
+
+
+class FakeProcess:
+    def __init__(self, stdout: str, returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.returncode = returncode
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return self.stdout.encode(), b""
+
+
+def fake_crosvm(
+    monkeypatch: pytest.MonkeyPatch,
+    list_output: str | list[str] = "devices",
+    attach_output: str = "ok 2",
+    detach_output: str | None = None,
+    list_returncode: int = 0,
+) -> list[tuple[str, ...]]:
+    calls: list[tuple[str, ...]] = []
+    list_outputs = [list_output] if isinstance(list_output, str) else list(list_output)
+
+    async def execute(*args: str, **_kwargs: Any) -> FakeProcess:
+        calls.append(args)
+        if args[1:3] == ("usb", "list"):
+            output = list_outputs.pop(0) if len(list_outputs) > 1 else list_outputs[0]
+            return FakeProcess(output, list_returncode)
+        if args[1:3] == ("usb", "attach"):
+            return FakeProcess(attach_output)
+        if args[1:3] == ("usb", "detach"):
+            return FakeProcess(detach_output if detach_output is not None else f"ok {args[3]}")
+        raise AssertionError(f"Unexpected Crosvm command: {args}")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", execute)
+    return calls
+
+
+def usb() -> USBInfo:
+    return USBInfo(device_node="/dev/bus/usb/001/002", vid="046d", pid="c52b")
+
+
+def link(monkeypatch: pytest.MonkeyPatch) -> CrosvmLink:
+    result = CrosvmLink("/run/app-vm.sock", "/nix/store/crosvm/bin/crosvm")
+    monkeypatch.setattr(result, "_wait_for_boot", lambda: True)
+    return result
+
+
+def test_adds_identical_device_when_port_is_not_known(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = fake_crosvm(monkeypatch, "devices 1 046d c52b")
+
+    port = asyncio.run(link(monkeypatch).add_usb_device(usb()))
+
+    assert port == 2
+    assert any(command[1:3] == ("usb", "attach") for command in calls)
+
+
+def test_reuses_persisted_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = fake_crosvm(monkeypatch, "devices 2 046d c52b")
+
+    port = asyncio.run(link(monkeypatch).add_usb_device(usb(), known_port=2))
+
+    assert port == 2
+    assert not any(command[1:3] == ("usb", "attach") for command in calls)
+
+
+def test_removes_exact_port_among_identical_devices(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = fake_crosvm(monkeypatch, "devices 1 046d c52b 2 046d c52b")
+
+    asyncio.run(link(monkeypatch).remove_usb_device(usb(), known_port=2))
+
+    detach_commands = [command for command in calls if command[1:3] == ("usb", "detach")]
+    assert detach_commands == [("/nix/store/crosvm/bin/crosvm", "usb", "detach", "2", "/run/app-vm.sock")]
+
+
+def test_refuses_to_remove_different_device_from_known_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = fake_crosvm(monkeypatch, "devices 2 1050 0407")
+
+    with pytest.raises(RuntimeError, match="different device"):
+        asyncio.run(link(monkeypatch).remove_usb_device(usb(), known_port=2))
+
+    assert not any(command[1:3] == ("usb", "detach") for command in calls)
+
+
+def test_refuses_ambiguous_legacy_removal(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = fake_crosvm(monkeypatch, "devices 1 046d c52b 2 046d c52b")
+
+    with pytest.raises(RuntimeError, match="cannot be identified safely"):
+        asyncio.run(link(monkeypatch).remove_usb_device(usb()))
+
+    assert not any(command[1:3] == ("usb", "detach") for command in calls)
+
+
+def test_malformed_ok_adopts_new_port_without_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = fake_crosvm(monkeypatch, ["devices 1 1234 5678", "devices 1 1234 5678 2 046d c52b"], "ok")
+
+    port = asyncio.run(link(monkeypatch).add_usb_device(usb()))
+
+    assert port == 2
+    assert len([command for command in calls if command[1:3] == ("usb", "attach")]) == 1
+
+
+def test_malformed_list_port_raises_runtime_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_crosvm(monkeypatch, "devices invalid 046d c52b")
+
+    with pytest.raises(RuntimeError, match="invalid literal"):
+        asyncio.run(link(monkeypatch).remove_usb_device(usb(), known_port=2))
+
+
+def test_empty_detach_response_raises_runtime_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_crosvm(monkeypatch, "devices 2 046d c52b", detach_output="")
+
+    with pytest.raises(RuntimeError, match="empty response"):
+        asyncio.run(link(monkeypatch).remove_usb_device(usb(), known_port=2))
+
+
+def test_unavailable_vm_has_distinct_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_crosvm(monkeypatch, list_returncode=1)
+    monkeypatch.setattr("vhotplug.crosvmlink.is_unix_socket_alive", lambda *_args: False)
+
+    with pytest.raises(CrosvmVMUnavailableError):
+        asyncio.run(link(monkeypatch).remove_usb_device(usb(), known_port=2))
+
+
+def test_no_available_port_does_not_detach_other_devices(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = fake_crosvm(monkeypatch, "devices 1 1234 5678", "no_available_port")
+    crosvm = link(monkeypatch)
+    crosvm.vm_retry_count = 0
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        asyncio.run(crosvm.add_usb_device(usb()))
+
+    assert not any(command[1:3] == ("usb", "detach") for command in calls)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,135 @@
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from vhotplug.crosvmlink import CrosvmVMUnavailableError
+from vhotplug.device import _attach_device_to_vm, _remove_device_from_vm
+from vhotplug.usb import USBInfo
+
+
+class FakeState:
+    def __init__(self, current_vm: str | None = "app-vm") -> None:
+        self.current_vm = current_vm
+        self.removed = False
+        self.attached_port: int | None = None
+
+    def get_vm_for_device(self, _dev_info: USBInfo) -> str | None:
+        return self.current_vm
+
+    def get_crosvm_usb_port(self, _dev_info: USBInfo, _vm_name: str, _socket_path: str) -> int:
+        return 7
+
+    def remove_vm_for_device(self, _dev_info: USBInfo) -> None:
+        self.removed = True
+
+    def set_vm_for_device(self, _dev_info: USBInfo, vm_name: str) -> None:
+        self.current_vm = vm_name
+
+    def set_crosvm_usb_port(
+        self,
+        _dev_info: USBInfo,
+        _vm_name: str,
+        _socket_path: str,
+        port: int | None,
+    ) -> None:
+        self.attached_port = port
+
+    def clear_disconnected(self, _dev_info: USBInfo) -> bool:
+        return False
+
+
+def usb() -> USBInfo:
+    return USBInfo(device_node="/dev/bus/usb/001/002", sys_name="1-2.1")
+
+
+def app_context(state: FakeState) -> Any:
+    config = SimpleNamespace(usb_authorization_enabled=lambda: False)
+    return SimpleNamespace(dev_state=state, config=config, api_server=None)
+
+
+def test_vm_unavailable_still_clears_local_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = FakeState()
+
+    async def unavailable(*_args: Any) -> None:
+        raise CrosvmVMUnavailableError("VM unavailable")
+
+    monkeypatch.setattr("vhotplug.device.vmm_remove_device", unavailable)
+
+    asyncio.run(
+        _remove_device_from_vm(
+            app_context(state),
+            usb(),
+            {"name": "app-vm", "type": "crosvm", "socket": "/run/app-vm.sock"},
+        )
+    )
+
+    assert state.removed
+
+
+def test_detach_refusal_preserves_local_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = FakeState()
+
+    async def refuse(*_args: Any) -> None:
+        raise RuntimeError("refusing to detach")
+
+    monkeypatch.setattr("vhotplug.device.vmm_remove_device", refuse)
+
+    with pytest.raises(RuntimeError, match="refusing"):
+        asyncio.run(
+            _remove_device_from_vm(
+                app_context(state),
+                usb(),
+                {"name": "app-vm", "type": "crosvm", "socket": "/run/app-vm.sock"},
+            )
+        )
+
+    assert not state.removed
+
+
+def test_move_does_not_attach_when_old_vm_removal_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = FakeState(current_vm="old-vm")
+    attached = False
+
+    async def remove(*_args: Any) -> None:
+        raise RuntimeError("old VM detach failed")
+
+    async def attach(*_args: Any) -> None:
+        nonlocal attached
+        attached = True
+
+    monkeypatch.setattr("vhotplug.device.remove_device", remove)
+    monkeypatch.setattr("vhotplug.device.vmm_add_device", attach)
+
+    with pytest.raises(RuntimeError, match="old VM detach failed"):
+        asyncio.run(
+            _attach_device_to_vm(
+                app_context(state),
+                usb(),
+                {"name": "new-vm", "type": "crosvm", "socket": "/run/new-vm.sock"},
+            )
+        )
+
+    assert not attached
+
+
+def test_crosvm_attach_passes_and_records_guest_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = FakeState(current_vm=None)
+
+    async def attach(*_args: Any) -> int:
+        assert _args[-1] == 7
+        return 9
+
+    monkeypatch.setattr("vhotplug.device.vmm_add_device", attach)
+
+    asyncio.run(
+        _attach_device_to_vm(
+            app_context(state),
+            usb(),
+            {"name": "app-vm", "type": "crosvm", "socket": "/run/app-vm.sock"},
+        )
+    )
+
+    assert state.current_vm == "app-vm"
+    assert state.attached_port == 9

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -215,6 +215,34 @@ def test_crosvm_args_isolate_hotplug_without_detected_devices(monkeypatch: pytes
     assert device_module.get_vmm_args(app_context, "net-vm", None) == ["--vfio-isolate-hotplug"]
 
 
+def test_required_pci_args_fail_without_detected_devices(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = SimpleNamespace(
+        get_vm=lambda _name: {"name": "net-vm", "type": "crosvm"},
+        has_pci_passthrough_for_vm=lambda _name: True,
+        get_acpi_tables=lambda _name: [],
+    )
+    app_context = cast(AppContext, SimpleNamespace(config=config))
+    monkeypatch.setattr(device_module, "_get_pci_devices", lambda *_args: [])
+    monkeypatch.setattr(device_module, "_get_evdev_devices", lambda *_args: [])
+
+    with pytest.raises(RuntimeError, match=r"configured.*no matching devices"):
+        device_module.get_vmm_args(app_context, "net-vm", None, require_pci=True)
+
+
+def test_required_pci_args_fail_without_configured_rules(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = SimpleNamespace(
+        get_vm=lambda _name: {"name": "net-vm", "type": "crosvm"},
+        has_pci_passthrough_for_vm=lambda _name: False,
+        get_acpi_tables=lambda _name: [],
+    )
+    app_context = cast(AppContext, SimpleNamespace(config=config))
+    monkeypatch.setattr(device_module, "_get_pci_devices", lambda *_args: [])
+    monkeypatch.setattr(device_module, "_get_evdev_devices", lambda *_args: [])
+
+    with pytest.raises(RuntimeError, match="No PCI passthrough rules"):
+        device_module.get_vmm_args(app_context, "net-vm", None, require_pci=True)
+
+
 def test_crosvm_args_can_place_pci_device_on_root_bus(monkeypatch: pytest.MonkeyPatch) -> None:
     config = SimpleNamespace(
         get_vm=lambda _name: {"name": "gui-vm", "type": "crosvm"},

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -215,6 +215,34 @@ def test_crosvm_args_isolate_hotplug_without_detected_devices(monkeypatch: pytes
     assert device_module.get_vmm_args(app_context, "net-vm", None) == ["--vfio-isolate-hotplug"]
 
 
+def test_crosvm_args_can_place_pci_device_on_root_bus(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = SimpleNamespace(
+        get_vm=lambda _name: {"name": "gui-vm", "type": "crosvm"},
+        has_pci_passthrough_for_vm=lambda _name: True,
+        get_acpi_tables=lambda _name: [],
+    )
+    passthrough_info = SimpleNamespace(
+        target_vm="gui-vm",
+        auto_ovmf=False,
+        qemu_use_root_bus=False,
+        crosvm_use_root_bus=True,
+    )
+    device = {
+        "pci_info": PCIInfo(address="0000:00:02.0"),
+        "passthrough_info": passthrough_info,
+    }
+    app_context = cast(AppContext, SimpleNamespace(config=config))
+    monkeypatch.setattr(device_module, "_get_pci_devices", lambda *_args: [device])
+    monkeypatch.setattr(device_module, "_get_evdev_devices", lambda *_args: [])
+    monkeypatch.setattr(device_module, "setup_vfio", lambda *_args: None)
+
+    assert device_module.get_vmm_args(app_context, "gui-vm", None) == [
+        "--vfio-isolate-hotplug",
+        "--vfio",
+        "/sys/bus/pci/devices/0000:00:02.0,iommu=viommu",
+    ]
+
+
 def test_attach_by_tag_propagates_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     received_fail_on_error = False
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -138,6 +138,32 @@ def test_crosvm_attach_passes_and_records_guest_port(monkeypatch: pytest.MonkeyP
     assert state.attached_port == 9
 
 
+def test_crosvm_pci_capability_is_checked_before_vfio_setup(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = FakeState(current_vm=None)
+    vfio_setup = False
+
+    async def unsupported(*_args: Any) -> None:
+        raise RuntimeError("VFIO list is unavailable")
+
+    def setup(*_args: Any) -> None:
+        nonlocal vfio_setup
+        vfio_setup = True
+
+    monkeypatch.setattr(device_module, "vmm_check_pci_hotplug", unsupported)
+    monkeypatch.setattr(device_module, "setup_vfio", setup)
+
+    with pytest.raises(RuntimeError, match="VFIO list is unavailable"):
+        asyncio.run(
+            _attach_device_to_vm(
+                app_context(state),
+                PCIInfo(address="0000:00:14.3"),
+                {"name": "net-vm", "type": "crosvm", "socket": "/run/net-vm.sock"},
+            )
+        )
+
+    assert not vfio_setup
+
+
 def pci_attach_context() -> tuple[AppContext, dict[str, Any]]:
     passthrough_info = SimpleNamespace(target_vm="net-vm", order=0)
     pci_info = PCIInfo(address="0000:00:14.3")
@@ -174,3 +200,50 @@ def test_background_reconciliation_logs_attach_failure(monkeypatch: pytest.Monke
     monkeypatch.setattr(device_module, "attach_device", fail_attach)
 
     asyncio.run(device_module.attach_connected_pci(app_context))
+
+
+def test_crosvm_args_isolate_hotplug_without_detected_devices(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = SimpleNamespace(
+        get_vm=lambda _name: {"name": "net-vm", "type": "crosvm"},
+        has_pci_passthrough_for_vm=lambda _name: True,
+        get_acpi_tables=lambda _name: [],
+    )
+    app_context = cast(AppContext, SimpleNamespace(config=config))
+    monkeypatch.setattr(device_module, "_get_pci_devices", lambda *_args: [])
+    monkeypatch.setattr(device_module, "_get_evdev_devices", lambda *_args: [])
+
+    assert device_module.get_vmm_args(app_context, "net-vm", None) == ["--vfio-isolate-hotplug"]
+
+
+def test_attach_by_tag_propagates_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    received_fail_on_error = False
+
+    async def attach(*_args: Any, **kwargs: Any) -> None:
+        nonlocal received_fail_on_error
+        received_fail_on_error = kwargs["fail_on_error"]
+
+    monkeypatch.setattr(device_module, "attach_connected_pci", attach)
+
+    asyncio.run(device_module.attach_existing_pci_devices_by_tag(cast(AppContext, object()), "audio"))
+
+    assert received_fail_on_error
+
+
+def test_explicit_pci_detach_propagates_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    pci_info = PCIInfo(address="0000:00:14.3")
+    state = SimpleNamespace(
+        list_pci_devices=lambda: [pci_info.address],
+        get_vm_for_device=lambda _pci_info: "net-vm",
+    )
+    passthrough_info = SimpleNamespace(skip_on_suspend=False, tag=None)
+    config = SimpleNamespace(vm_for_device=lambda _pci_info: passthrough_info)
+    app_context = cast(AppContext, SimpleNamespace(dev_state=state, config=config))
+    monkeypatch.setattr(device_module, "pci_info_by_address", lambda *_args: pci_info)
+
+    async def fail_remove(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("Crosvm VFIO remove failed")
+
+    monkeypatch.setattr(device_module, "_remove_existing_device", fail_remove)
+
+    with pytest.raises(RuntimeError, match="Crosvm VFIO remove failed"):
+        asyncio.run(device_module.detach_connected_pci(app_context, fail_on_error=True))

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,11 +1,14 @@
 import asyncio
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
+from vhotplug import device as device_module
+from vhotplug.appcontext import AppContext
 from vhotplug.crosvmlink import CrosvmVMUnavailableError
 from vhotplug.device import _attach_device_to_vm, _remove_device_from_vm
+from vhotplug.pci import PCIInfo
 from vhotplug.usb import USBInfo
 
 
@@ -133,3 +136,41 @@ def test_crosvm_attach_passes_and_records_guest_port(monkeypatch: pytest.MonkeyP
 
     assert state.current_vm == "app-vm"
     assert state.attached_port == 9
+
+
+def pci_attach_context() -> tuple[AppContext, dict[str, Any]]:
+    passthrough_info = SimpleNamespace(target_vm="net-vm", order=0)
+    pci_info = PCIInfo(address="0000:00:14.3")
+    device = {
+        "pci_info": pci_info,
+        "passthrough_info": passthrough_info,
+        "current_vm": None,
+        "iommu_member": False,
+    }
+    config = SimpleNamespace(get_vm=lambda _name: {"name": "net-vm", "type": "crosvm"})
+    return cast(AppContext, SimpleNamespace(config=config)), device
+
+
+def test_pci_resume_propagates_attach_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    app_context, device = pci_attach_context()
+    monkeypatch.setattr(device_module, "_get_pci_devices", lambda *_args: [device])
+
+    async def fail_attach(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("Crosvm VFIO add failed")
+
+    monkeypatch.setattr(device_module, "attach_device", fail_attach)
+
+    with pytest.raises(RuntimeError, match=r"0000:00:14\.3.*Crosvm VFIO add failed"):
+        asyncio.run(device_module.attach_connected_pci(app_context, fail_on_error=True))
+
+
+def test_background_reconciliation_logs_attach_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    app_context, device = pci_attach_context()
+    monkeypatch.setattr(device_module, "_get_pci_devices", lambda *_args: [device])
+
+    async def fail_attach(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("Crosvm VFIO add failed")
+
+    monkeypatch.setattr(device_module, "attach_device", fail_attach)
+
+    asyncio.run(device_module.attach_connected_pci(app_context))

--- a/tests/test_devicestate.py
+++ b/tests/test_devicestate.py
@@ -1,0 +1,117 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from vhotplug.devicestate import DeviceState
+from vhotplug.usb import USBInfo
+
+
+def usb(device_node: str = "/dev/bus/usb/001/002", vid: str = "046d") -> USBInfo:
+    return USBInfo(device_node=device_node, vid=vid, pid="c52b", serial="serial", sys_name="1-2.1")
+
+
+def test_crosvm_usb_port_is_scoped_to_vm_socket_generation(tmp_path: Path) -> None:
+    state_path = tmp_path / "vhotplug.state"
+    socket_path = tmp_path / "app-vm.sock"
+    socket_path.touch()
+    state = DeviceState(True, str(state_path))
+    state.set_crosvm_usb_port(usb(), "app-vm", str(socket_path), 7)
+
+    reloaded = DeviceState(True, str(state_path))
+    assert reloaded.get_crosvm_usb_port(usb(), "app-vm", str(socket_path)) == 7
+
+    socket_path.unlink()
+    socket_path.touch()
+    assert reloaded.get_crosvm_usb_port(usb(), "app-vm", str(socket_path)) is None
+
+
+def test_crosvm_usb_port_uses_topology_and_validates_identity(tmp_path: Path) -> None:
+    state_path = tmp_path / "vhotplug.state"
+    socket_path = tmp_path / "app-vm.sock"
+    socket_path.touch()
+    state = DeviceState(True, str(state_path))
+    state.set_crosvm_usb_port(usb(), "app-vm", str(socket_path), 7)
+
+    renumbered = usb("/dev/bus/usb/001/009")
+    assert state.get_crosvm_usb_port(renumbered, "app-vm", str(socket_path)) == 7
+    assert state.get_crosvm_usb_port(usb(vid="1050"), "app-vm", str(socket_path)) is None
+
+
+def test_crosvm_usb_port_is_removed_with_device_state(tmp_path: Path) -> None:
+    state_path = tmp_path / "vhotplug.state"
+    socket_path = tmp_path / "app-vm.sock"
+    socket_path.touch()
+    state = DeviceState(True, str(state_path))
+    state.set_crosvm_usb_port(usb(), "app-vm", str(socket_path), 7)
+
+    state.remove_vm_for_device(usb())
+
+    assert state.get_crosvm_usb_port(usb(), "app-vm", str(socket_path)) is None
+
+
+def test_crosvm_usb_port_is_scoped_to_vm(tmp_path: Path) -> None:
+    state_path = tmp_path / "vhotplug.state"
+    socket_path = tmp_path / "app-vm.sock"
+    socket_path.touch()
+    state = DeviceState(True, str(state_path))
+    state.set_crosvm_usb_port(usb(), "app-vm", str(socket_path), 7)
+
+    assert state.get_crosvm_usb_port(usb(), "other-vm", str(socket_path)) is None
+
+
+def test_invalid_state_starts_empty(tmp_path: Path) -> None:
+    state_path = tmp_path / "vhotplug.state"
+    state_path.write_text('{"selected_vms":', encoding="utf-8")
+
+    state = DeviceState(True, str(state_path))
+
+    assert state.selected_vms == {}
+    assert state.crosvm_usb_port_map == {}
+
+
+def test_boolean_port_is_discarded(tmp_path: Path) -> None:
+    state_path = tmp_path / "vhotplug.state"
+    state_path.write_text(
+        json.dumps(
+            {
+                "crosvm_usb_ports": {
+                    "1-2.1": {
+                        "vm": "app-vm",
+                        "port": True,
+                        "socket_generation": "1:2:3",
+                        "vid": "046d",
+                        "pid": "c52b",
+                        "serial": None,
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert DeviceState(True, str(state_path)).crosvm_usb_port_map == {}
+
+
+def test_state_file_is_private(tmp_path: Path) -> None:
+    state_path = tmp_path / "vhotplug.state"
+    state = DeviceState(True, str(state_path))
+    state.select_vm_for_device(usb(), "app-vm")
+
+    assert os.stat(state_path).st_mode & 0o777 == 0o600
+
+
+def test_state_save_failure_does_not_replace_valid_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state_path = tmp_path / "vhotplug.state"
+    state = DeviceState(True, str(state_path))
+    state.select_vm_for_device(usb(), "app-vm")
+    saved = state_path.read_text(encoding="utf-8")
+
+    def fail_replace(_self: Path, _target: Path) -> None:
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(Path, "replace", fail_replace)
+    state.set_disconnected(usb())
+
+    assert state_path.read_text(encoding="utf-8") == saved

--- a/tests/test_vhotplug.py
+++ b/tests/test_vhotplug.py
@@ -1,0 +1,53 @@
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from vhotplug.appcontext import AppContext
+from vhotplug.devicestate import DeviceState
+from vhotplug.usb import USBInfo
+from vhotplug.vhotplug import reattach_devices_for_restarted_vms
+
+
+def usb() -> USBInfo:
+    return USBInfo(
+        device_node="/dev/bus/usb/001/002",
+        vid="0bda",
+        pid="8153",
+        serial="ethernet",
+        sys_name="1-2.1",
+    )
+
+
+def test_queued_socket_event_preserves_current_usb_port(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    socket_path = tmp_path / "net-vm.sock"
+    socket_path.touch()
+    state = DeviceState(False, str(tmp_path / "vhotplug.state"))
+    state.set_crosvm_usb_port(usb(), "net-vm", str(socket_path), 4)
+    app_context = SimpleNamespace(
+        config=SimpleNamespace(get_vm_by_socket=lambda path: {"name": "net-vm"} if path == str(socket_path) else None),
+        dev_state=state,
+    )
+    calls: list[tuple[str, list[str]]] = []
+
+    async def record(name: str, _app_context: Any, vm_names: list[str] | None = None) -> None:
+        calls.append((name, vm_names or []))
+
+    monkeypatch.setattr("vhotplug.vhotplug.attach_connected_evdev", lambda context: record("evdev", context))
+    monkeypatch.setattr("vhotplug.vhotplug.attach_connected_pci", lambda context, names: record("pci", context, names))
+    monkeypatch.setattr(
+        "vhotplug.vhotplug.detach_disconnected_pci", lambda context, names: record("pci-detach", context, names)
+    )
+    monkeypatch.setattr("vhotplug.vhotplug.attach_connected_usb", lambda context, names: record("usb", context, names))
+
+    asyncio.run(reattach_devices_for_restarted_vms(cast(AppContext, app_context), [str(socket_path)]))
+
+    assert state.get_crosvm_usb_port(usb(), "net-vm", str(socket_path)) == 4
+    assert calls == [
+        ("evdev", []),
+        ("pci", ["net-vm"]),
+        ("pci-detach", ["net-vm"]),
+        ("usb", ["net-vm"]),
+    ]

--- a/tests/test_vmm.py
+++ b/tests/test_vmm.py
@@ -1,12 +1,21 @@
 import asyncio
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
+from vhotplug import vmm as vmm_module
+from vhotplug.appcontext import AppContext
 from vhotplug.pci import PCIInfo, pci_is_nvidia_gpu
 from vhotplug.usb import USBInfo
-from vhotplug.vmm import vmm_add_device, vmm_args_ovmf, vmm_args_pci
+from vhotplug.vmm import (
+    vmm_add_device,
+    vmm_args_acpi_table,
+    vmm_args_ovmf,
+    vmm_args_pci,
+    vmm_is_pci_dev_connected,
+    vmm_wait_until_removed,
+)
 
 
 def test_pci_is_nvidia_gpu_display_controller() -> None:
@@ -98,3 +107,41 @@ def test_vmm_add_device_returns_none_for_qemu_usb(monkeypatch: pytest.MonkeyPatc
     )
 
     assert port is None
+
+
+def test_vmm_args_pci_crosvm_is_removable() -> None:
+    assert vmm_args_pci({"type": "crosvm"}, PCIInfo(address="0000:00:1f.3"), 0, None) == [
+        "--vfio",
+        "/sys/bus/pci/devices/0000:00:1f.3,iommu=viommu,removable=true",
+    ]
+
+
+def test_vmm_args_acpi_table_crosvm() -> None:
+    assert vmm_args_acpi_table({"type": "crosvm"}, "/run/nhlt.aml") == ["--acpi-table", "/run/nhlt.aml"]
+
+
+def test_crosvm_pci_queries_use_configured_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    binaries: list[str | None] = []
+
+    class FakeCrosvmLink:
+        def __init__(self, _socket: str, crosvm_bin: str | None) -> None:
+            binaries.append(crosvm_bin)
+
+        async def is_pci_dev_connected(self, _pci_info: PCIInfo) -> bool:
+            return True
+
+        async def wait_until_pci_removed(self, _pci_info: PCIInfo) -> None:
+            return
+
+    monkeypatch.setattr(vmm_module, "CrosvmLink", FakeCrosvmLink)
+    app_context = cast(
+        AppContext,
+        SimpleNamespace(config=SimpleNamespace(config={"general": {"crosvm": "/nix/store/crosvm/bin/crosvm"}})),
+    )
+    vm = {"type": "crosvm", "socket": "/run/net-vm.sock"}
+    pci_info = PCIInfo(address="0000:00:14.3")
+
+    assert asyncio.run(vmm_is_pci_dev_connected(app_context, vm, pci_info))
+    asyncio.run(vmm_wait_until_removed(app_context, vm, pci_info))
+
+    assert binaries == ["/nix/store/crosvm/bin/crosvm"] * 2

--- a/tests/test_vmm.py
+++ b/tests/test_vmm.py
@@ -116,6 +116,13 @@ def test_vmm_args_pci_crosvm_is_removable() -> None:
     ]
 
 
+def test_vmm_args_pci_crosvm_can_use_root_bus() -> None:
+    assert vmm_args_pci({"type": "crosvm"}, PCIInfo(address="0000:00:02.0"), 0, None, False, True) == [
+        "--vfio",
+        "/sys/bus/pci/devices/0000:00:02.0,iommu=viommu",
+    ]
+
+
 def test_vmm_args_acpi_table_crosvm() -> None:
     assert vmm_args_acpi_table({"type": "crosvm"}, "/run/nhlt.aml") == ["--acpi-table", "/run/nhlt.aml"]
 

--- a/tests/test_vmm.py
+++ b/tests/test_vmm.py
@@ -1,7 +1,12 @@
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
 import pytest
 
 from vhotplug.pci import PCIInfo, pci_is_nvidia_gpu
-from vhotplug.vmm import vmm_args_ovmf, vmm_args_pci
+from vhotplug.usb import USBInfo
+from vhotplug.vmm import vmm_add_device, vmm_args_ovmf, vmm_args_pci
 
 
 def test_pci_is_nvidia_gpu_display_controller() -> None:
@@ -47,3 +52,49 @@ def test_vmm_args_pci_uses_default_bus() -> None:
         "-device",
         "vfio-pci,host=0000:01:00.0,multifunction=on,id=vhp-pci-3",
     ]
+
+
+def test_vmm_add_device_returns_crosvm_usb_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeCrosvm:
+        def __init__(self, *_args: Any) -> None:
+            pass
+
+        async def add_usb_device(self, _usb_info: USBInfo, known_port: int | None) -> int:
+            assert known_port == 3
+            return 7
+
+    monkeypatch.setattr("vhotplug.vmm.CrosvmLink", FakeCrosvm)
+    app_context: Any = SimpleNamespace(config=SimpleNamespace(config={}))
+
+    port = asyncio.run(
+        vmm_add_device(
+            app_context,
+            {"name": "app-vm", "type": "crosvm", "socket": "/run/app-vm.sock"},
+            USBInfo(device_node="/dev/bus/usb/001/002"),
+            3,
+        )
+    )
+
+    assert port == 7
+
+
+def test_vmm_add_device_returns_none_for_qemu_usb(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeQemu:
+        def __init__(self, *_args: Any) -> None:
+            pass
+
+        async def add_usb_device(self, _usb_info: USBInfo) -> None:
+            pass
+
+    monkeypatch.setattr("vhotplug.vmm.QEMULink", FakeQemu)
+    app_context: Any = SimpleNamespace(config=SimpleNamespace(config={}))
+
+    port = asyncio.run(
+        vmm_add_device(
+            app_context,
+            {"name": "app-vm", "type": "qemu", "socket": "/run/app-vm.sock"},
+            USBInfo(device_node="/dev/bus/usb/001/002"),
+        )
+    )
+
+    assert port is None

--- a/tests/test_vmm.py
+++ b/tests/test_vmm.py
@@ -145,3 +145,16 @@ def test_crosvm_pci_queries_use_configured_binary(monkeypatch: pytest.MonkeyPatc
     asyncio.run(vmm_wait_until_removed(app_context, vm, pci_info))
 
     assert binaries == ["/nix/store/crosvm/bin/crosvm"] * 2
+
+
+def test_pci_query_rejects_unknown_vmm() -> None:
+    app_context = cast(AppContext, SimpleNamespace(config=SimpleNamespace(config={})))
+
+    with pytest.raises(RuntimeError, match="Unsupported vm type"):
+        asyncio.run(
+            vmm_is_pci_dev_connected(
+                app_context,
+                {"type": "typo", "socket": "/run/unknown.sock"},
+                PCIInfo(address="0000:00:14.3"),
+            )
+        )

--- a/vhotplug/apiserver.py
+++ b/vhotplug/apiserver.py
@@ -464,7 +464,12 @@ class APIServer:
         vm = msg.get("vm")
         logger.info("PCI resume: %s", vm)
         asyncio.run_coroutine_threadsafe(
-            attach_connected_pci(self.app_context, [vm] if vm else None), self.loop
+            attach_connected_pci(
+                self.app_context,
+                [vm] if vm else None,
+                fail_on_error=True,
+            ),
+            self.loop,
         ).result()
         return {"result": "ok"}
 

--- a/vhotplug/apiserver.py
+++ b/vhotplug/apiserver.py
@@ -456,7 +456,13 @@ class APIServer:
         vm = msg.get("vm")
         logger.info("PCI suspend: %s", vm)
         asyncio.run_coroutine_threadsafe(
-            detach_connected_pci(self.app_context, [vm] if vm else None, suspend=True), self.loop
+            detach_connected_pci(
+                self.app_context,
+                [vm] if vm else None,
+                suspend=True,
+                fail_on_error=True,
+            ),
+            self.loop,
         ).result()
         return {"result": "ok"}
 

--- a/vhotplug/apiserver.py
+++ b/vhotplug/apiserver.py
@@ -485,5 +485,6 @@ class APIServer:
             raise RuntimeError("VM name is required")
         qemu_bus_prefix = msg.get("qemu_bus_prefix")
         qemu_bus_start_index = int(msg.get("qemu_bus_start_index", 0))
-        args = get_vmm_args(self.app_context, vm, qemu_bus_prefix, qemu_bus_start_index)
+        require_pci = bool(msg.get("require_pci", False))
+        args = get_vmm_args(self.app_context, vm, qemu_bus_prefix, qemu_bus_start_index, require_pci)
         return {"result": "ok", "vmm_args": args}

--- a/vhotplug/config.py
+++ b/vhotplug/config.py
@@ -22,6 +22,7 @@ class PassthroughInfo:
     qemu_use_root_bus: bool = False
     order: int = 0
     tag: str | None = None
+    crosvm_use_root_bus: bool = False
 
 
 @dataclass
@@ -368,6 +369,7 @@ class Config:
                     pci_iommu_skip_if_shared = rule.get("pciIommuSkipIfShared", False)
                     auto_ovmf = rule.get("autoOvmf", False)
                     qemu_use_root_bus = rule.get("qemuUseRootBus", False)
+                    crosvm_use_root_bus = rule.get("crosvmUseRootBus", False)
                     tag = rule.get("tag")
                     return PassthroughInfo(
                         target_vm,
@@ -379,6 +381,7 @@ class Config:
                         qemu_use_root_bus,
                         order,
                         tag,
+                        crosvm_use_root_bus,
                     )
 
         except (AttributeError, TypeError):

--- a/vhotplug/config.py
+++ b/vhotplug/config.py
@@ -504,6 +504,17 @@ class Config:
             logger.exception("Failed to find ACPI tables for %s", vm_name)
         return acpi_tables
 
+    def has_pci_passthrough_for_vm(self, vm_name: str) -> bool:
+        """Return whether an enabled PCI rule targets the VM."""
+        try:
+            return any(
+                not self._disabled(rule) and rule.get("targetVm") == vm_name
+                for rule in self.config.get("pciPassthrough", [])
+            )
+        except (AttributeError, TypeError):
+            logger.exception("Failed to inspect PCI passthrough rules for %s", vm_name)
+            return False
+
     def usb_authorization_enabled(self) -> bool:
         return bool(self._enabled(self.config.get("usbAuthorization", {}), False))
 

--- a/vhotplug/crosvmlink.py
+++ b/vhotplug/crosvmlink.py
@@ -1,12 +1,21 @@
 import asyncio
 import logging
 import socket
+from typing import ClassVar
 
-from vhotplug.misc import wait_for_unix_socket
+from vhotplug.misc import is_unix_socket_alive, wait_for_unix_socket
 from vhotplug.pci import PCIInfo
 from vhotplug.usb import USBInfo
 
 logger = logging.getLogger("vhotplug")
+
+
+class CrosvmVMUnavailableError(RuntimeError):
+    """Raised when a Crosvm control socket is unavailable."""
+
+
+class CrosvmUSBAttachStateError(RuntimeError):
+    """Raised when Crosvm attached a USB device without identifying its port."""
 
 
 class CrosvmLink:
@@ -14,6 +23,7 @@ class CrosvmLink:
     vm_retry_timeout = 1
     vm_wait_after_boot = 3
     vm_boot_timeout = 10
+    usb_locks: ClassVar[dict[str, asyncio.Lock]] = {}
 
     def __init__(self, socket_path: str, crosvm_bin: str | None) -> None:
         self.socket_path = socket_path
@@ -28,7 +38,11 @@ class CrosvmLink:
             self.socket_path, self.vm_boot_timeout, self.vm_wait_after_boot, socket.SOCK_SEQPACKET
         )
 
-    async def add_usb_device(self, usb_info: USBInfo) -> None:
+    async def add_usb_device(self, usb_info: USBInfo, known_port: int | None = None) -> int:
+        async with self.usb_locks.setdefault(self.socket_path, asyncio.Lock()):
+            return await self._add_usb_device(usb_info, known_port)
+
+    async def _add_usb_device(self, usb_info: USBInfo, known_port: int | None = None) -> int:
         dev_node = usb_info.device_node
         assert dev_node is not None, "Device node must be set"
 
@@ -36,22 +50,24 @@ class CrosvmLink:
         if not self._wait_for_boot():
             logger.warning("VM is not booted while adding device %s", dev_node)
 
-        i = 0
-        while True:
+        last_error: Exception | None = None
+        for attempt in range(self.vm_retry_count + 1):
             try:
                 logger.info("Adding USB device %s to %s", dev_node, self.socket_path)
 
-                # Check if the device is already connected
+                # Reuse a persisted port after a daemon restart if it still
+                # contains the expected device. VID/PID alone is not a unique
+                # identity because multiple identical USB devices may exist.
                 devices = await self.usb_list()
-                for _, vid, pid in devices:
-                    if vid == usb_info.vid and pid == usb_info.pid:
+                for port, vid, pid in devices:
+                    if port == known_port and vid == usb_info.vid and pid == usb_info.pid:
                         logger.info(
-                            "Device %s:%s is already attached to %s, skipping",
-                            vid,
-                            pid,
+                            "Device %s is already attached to %s on port %s, skipping",
+                            dev_node,
                             self.socket_path,
+                            port,
                         )
-                        return
+                        return port
 
                 proc = await asyncio.create_subprocess_exec(
                     self.crosvm_bin,
@@ -70,6 +86,7 @@ class CrosvmLink:
                 stderr_str = stderr_bytes.decode()
 
                 if proc.returncode != 0:
+                    last_error = RuntimeError(f"Crosvm USB attach failed with code {proc.returncode}")
                     logger.warning(
                         "Failed to add device %s, error code: %s",
                         dev_node,
@@ -78,38 +95,79 @@ class CrosvmLink:
                     logger.warning("Out: %s", stdout_str)
                     logger.warning("Err: %s", stderr_str)
                 else:
-                    r = stdout_str.split()
+                    r = self._parse_usb_attach_response(stdout_str)
                     if r[0] == "ok":
-                        logger.info("Attached USB device %s, id: %s", dev_node, r[1])
-                        return
+                        if len(r) == 2:
+                            try:
+                                port = self._parse_usb_port(r[1])
+                            except ValueError:
+                                logger.warning("Crosvm returned an invalid USB port: %s", r[1])
+                            else:
+                                logger.info("Attached USB device %s, id: %s", dev_node, port)
+                                return port
+                        port = await self._recover_attached_usb_port(usb_info, devices)
+                        logger.info("Attached USB device %s, id: %s", dev_node, port)
+                        return port
                     if r[0] == "no_available_port":
-                        # Crosvm supports attaching USB devices only after the kernel has booted
-                        # Here, we may attempt to attach a device before that which will return no_available_port
-                        # If we keep trying, it may eventually return I/O error and USB passthrough won't work until the VM is rebooted
-                        # As a workaround we remove USB devices here even if it returns no_such_device
-                        # This helps prevent I/O errors and allows USB to be successfully attached once the VM boots
-                        logger.info("No available port, removing all devices")
-                        devices = await self.usb_list()
-                        try:
-                            for index, _, _ in devices:
-                                await self.remove_usb_device_by_id(index)
-                        except RuntimeError as e:
-                            logger.warning("Failed to remove: %s", str(e))
+                        # This can be transient while the guest xHCI driver is
+                        # starting, or permanent when every port is occupied.
+                        # Never detach unrelated devices to make room.
+                        logger.info("No Crosvm USB port is available yet")
                     else:
+                        last_error = RuntimeError("Unexpected Crosvm USB attach response")
                         logger.warning("Unexpected result: %s", r[0])
                         logger.warning("Out: %s", stdout_str)
                         logger.warning("Err: %s", stderr_str)
-            except OSError as e:
+            except CrosvmUSBAttachStateError:
+                raise
+            except (OSError, RuntimeError, ValueError) as e:
+                last_error = e
                 logger.warning("Failed to attach USB device %s: %s", dev_node, e)
 
-            if i < self.vm_retry_count:
+            if attempt < self.vm_retry_count:
                 logger.info("Retrying")
                 await asyncio.sleep(self.vm_retry_timeout)
-                i += 1
-            else:
-                break
-        logger.error("Failed to add USB device %s after %s attempts", dev_node, i)
-        raise RuntimeError("Timeout")
+        logger.error("Failed to add USB device %s after %s attempts", dev_node, self.vm_retry_count + 1)
+        raise RuntimeError("Crosvm USB attach timed out") from last_error
+
+    @staticmethod
+    def _parse_usb_port(value: str) -> int:
+        port = int(value)
+        if not 0 <= port <= 255:
+            raise ValueError(f"Invalid Crosvm USB port: {port}")
+        return port
+
+    @staticmethod
+    def _parse_usb_attach_response(stdout: str) -> list[str]:
+        result = stdout.split()
+        if not result:
+            raise RuntimeError("Crosvm returned an empty USB attach response")
+        return result
+
+    @staticmethod
+    def _single_new_usb_port(matches: list[int]) -> int:
+        if len(matches) != 1:
+            raise CrosvmUSBAttachStateError("Crosvm attached the USB device but did not report its port")
+        return matches[0]
+
+    async def _recover_attached_usb_port(
+        self,
+        usb_info: USBInfo,
+        devices_before: list[tuple[int, str, str]],
+    ) -> int:
+        try:
+            devices_after = await self.usb_list()
+        except RuntimeError as e:
+            raise CrosvmUSBAttachStateError(
+                "Crosvm attached the USB device but its port could not be determined"
+            ) from e
+        old_ports = {port for port, _, _ in devices_before}
+        matches = [
+            port
+            for port, vid, pid in devices_after
+            if port not in old_ports and vid == usb_info.vid and pid == usb_info.pid
+        ]
+        return self._single_new_usb_port(matches)
 
     async def remove_usb_device_by_id(self, dev_id: int) -> None:
         try:
@@ -135,11 +193,12 @@ class CrosvmLink:
                 logger.error("Err: %s", stderr_str)
                 raise RuntimeError(proc.returncode)
             r = stdout_str.split()
-            if r[0] != "ok":
-                logger.error("Unexpected result: %s", r[0])
+            if not r or r[0] != "ok":
+                result = r[0] if r else "empty response"
+                logger.error("Unexpected result: %s", result)
                 logger.error("Out: %s", stdout_str)
                 logger.error("Err: %s", stderr_str)
-                raise RuntimeError(r[0])
+                raise RuntimeError(result)
             logger.info("Detached USB device %s", dev_id)
             return
         except OSError as e:
@@ -165,34 +224,66 @@ class CrosvmLink:
             stderr_str = stderr_bytes.decode()
 
             if proc.returncode != 0:
-                logger.error("Failed to get USB list, error code: %s", proc.returncode)
-                logger.error("Out: %s", stdout_str)
-                logger.error("Err: %s", stderr_str)
-            else:
-                r = stdout_str.split()
-                if r[0] != "devices":
-                    logger.error("Unexpected result: %s", r[0])
-                    logger.error("Out: %s", stdout_str)
-                    logger.error("Err: %s", stderr_str)
-                else:
-                    data = r[1:]
-                    for i in range(0, len(data), 3):
-                        index = int(data[i])
-                        vid = data[i + 1]
-                        pid = data[i + 2]
-                        devices.append((index, vid, pid))
-                        logger.debug("USB device %s: %s:%s", index, vid, pid)
+                logger.error("Crosvm USB list failed with code %s: %s", proc.returncode, stderr_str.strip())
+                if not is_unix_socket_alive(self.socket_path, socket.SOCK_SEQPACKET):
+                    raise CrosvmVMUnavailableError("Crosvm VM is unavailable")
+                raise RuntimeError(f"Crosvm USB list failed with code {proc.returncode}")
 
-        except OSError:
+            result = stdout_str.split()
+            if not result or result[0] != "devices" or len(result[1:]) % 3 != 0:
+                logger.error("Malformed Crosvm USB list response: %s", stdout_str.strip())
+                raise RuntimeError("Malformed Crosvm USB list response")
+
+            data = result[1:]
+            for i in range(0, len(data), 3):
+                index = self._parse_usb_port(data[i])
+                vid = data[i + 1]
+                pid = data[i + 2]
+                devices.append((index, vid, pid))
+                logger.debug("USB device %s: %s:%s", index, vid, pid)
+
+        except (OSError, ValueError) as e:
             logger.exception("Failed to list USB devices")
+            raise RuntimeError(e) from None
         return devices
 
-    async def remove_usb_device(self, usb_info: USBInfo) -> None:
+    async def remove_usb_device(self, usb_info: USBInfo, known_port: int | None = None) -> None:
+        async with self.usb_locks.setdefault(self.socket_path, asyncio.Lock()):
+            await self._remove_usb_device(usb_info, known_port)
+
+    async def _remove_usb_device(self, usb_info: USBInfo, known_port: int | None = None) -> None:
         devices = await self.usb_list()
-        for index, crosvm_vid, crosvm_pid in devices:
-            if usb_info.vid == crosvm_vid and usb_info.pid == crosvm_pid:
-                logger.debug("Removing %s from %s", index, self.socket_path)
-                await self.remove_usb_device_by_id(index)
+        if known_port is not None:
+            device = next((dev for dev in devices if dev[0] == known_port), None)
+            if device is None:
+                logger.debug("USB port %s is already empty", known_port)
+                return
+
+            _, crosvm_vid, crosvm_pid = device
+            if usb_info.vid and usb_info.pid and (usb_info.vid != crosvm_vid or usb_info.pid != crosvm_pid):
+                logger.error(
+                    "USB port %s now contains %s:%s instead of %s:%s; not detaching it",
+                    known_port,
+                    crosvm_vid,
+                    crosvm_pid,
+                    usb_info.vid,
+                    usb_info.pid,
+                )
+                raise RuntimeError("Crosvm USB port contains a different device; refusing to detach")
+
+            await self.remove_usb_device_by_id(known_port)
+            return
+
+        matches = [
+            index
+            for index, crosvm_vid, crosvm_pid in devices
+            if usb_info.vid == crosvm_vid and usb_info.pid == crosvm_pid
+        ]
+        if len(matches) > 1:
+            logger.error("Multiple Crosvm USB devices match %s:%s", usb_info.vid, usb_info.pid)
+            raise RuntimeError("Crosvm USB device cannot be identified safely")
+        if matches:
+            await self.remove_usb_device_by_id(matches[0])
 
     async def add_pci_device(self, _pci_info: PCIInfo) -> None:
         raise RuntimeError("Not implemented")

--- a/vhotplug/crosvmlink.py
+++ b/vhotplug/crosvmlink.py
@@ -286,7 +286,85 @@ class CrosvmLink:
             await self.remove_usb_device_by_id(matches[0])
 
     async def add_pci_device(self, _pci_info: PCIInfo) -> None:
-        raise RuntimeError("Not implemented")
+        pci_path = self._pci_path(_pci_info)
+        if not self._wait_for_boot():
+            logger.warning("VM is not booted while adding PCI device %s", pci_path)
+
+        for attempt in range(self.vm_retry_count + 1):
+            try:
+                if pci_path in await self.pci_list():
+                    logger.info("PCI device %s is already attached", pci_path)
+                    return
+                await self._run_vfio_command("add", pci_path)
+                if pci_path in await self.pci_list():
+                    return
+            except RuntimeError as error:
+                logger.warning("Failed to attach PCI device %s: %s", pci_path, error)
+            if attempt < self.vm_retry_count:
+                await asyncio.sleep(self.vm_retry_timeout)
+
+        raise RuntimeError(f"Timed out attaching PCI device {pci_path}")
 
     async def remove_pci_device(self, _pci_info: PCIInfo) -> None:
-        raise RuntimeError("Not implemented")
+        pci_path = self._pci_path(_pci_info)
+        for attempt in range(self.vm_retry_count + 1):
+            try:
+                if pci_path not in await self.pci_list():
+                    logger.debug("PCI device %s is already detached", pci_path)
+                    return
+                await self._run_vfio_command("remove", pci_path)
+                if pci_path not in await self.pci_list():
+                    return
+            except RuntimeError as error:
+                logger.warning("Failed to detach PCI device %s: %s", pci_path, error)
+            if attempt < self.vm_retry_count:
+                await asyncio.sleep(self.vm_retry_timeout)
+
+        raise RuntimeError(f"Timed out detaching PCI device {pci_path}")
+
+    async def pci_list(self) -> list[str]:
+        stdout = await self._run_vfio_command("list")
+        result = stdout.split()
+        if not result or result[0] != "devices":
+            raise RuntimeError(f"Malformed Crosvm VFIO list response: {stdout.strip()}")
+        return result[1:]
+
+    async def is_pci_dev_connected(self, pci_info: PCIInfo) -> bool:
+        return self._pci_path(pci_info) in await self.pci_list()
+
+    async def wait_until_pci_removed(self, pci_info: PCIInfo) -> None:
+        pci_path = self._pci_path(pci_info)
+        for attempt in range(self.vm_retry_count + 1):
+            try:
+                if pci_path not in await self.pci_list():
+                    return
+            except RuntimeError as error:
+                logger.warning("Failed to query PCI device %s during removal: %s", pci_path, error)
+            if attempt < self.vm_retry_count:
+                await asyncio.sleep(self.vm_retry_timeout)
+        raise RuntimeError(f"Timed out waiting for PCI device removal: {pci_path}")
+
+    async def _run_vfio_command(self, command: str, pci_path: str | None = None) -> str:
+        args = [self.crosvm_bin, "vfio", command]
+        if pci_path is not None:
+            args.append(pci_path)
+        args.append(self.socket_path)
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout_bytes, stderr_bytes = await proc.communicate()
+        except OSError as error:
+            raise RuntimeError(f"Failed to execute Crosvm VFIO {command}: {error}") from None
+
+        stdout = stdout_bytes.decode()
+        stderr = stderr_bytes.decode().strip()
+        if proc.returncode != 0:
+            raise RuntimeError(f"Crosvm VFIO {command} failed with code {proc.returncode}: {stderr}")
+        return stdout
+
+    @staticmethod
+    def _pci_path(pci_info: PCIInfo) -> str:
+        return f"/sys/bus/pci/devices/{pci_info.address}"

--- a/vhotplug/crosvmlink.py
+++ b/vhotplug/crosvmlink.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import re
 import socket
 from typing import ClassVar
 
@@ -23,6 +24,7 @@ class CrosvmLink:
     vm_retry_timeout = 1
     vm_wait_after_boot = 3
     vm_boot_timeout = 10
+    vfio_command_timeout: float = 10
     usb_locks: ClassVar[dict[str, asyncio.Lock]] = {}
 
     def __init__(self, socket_path: str, crosvm_bin: str | None) -> None:
@@ -37,6 +39,15 @@ class CrosvmLink:
         return wait_for_unix_socket(
             self.socket_path, self.vm_boot_timeout, self.vm_wait_after_boot, socket.SOCK_SEQPACKET
         )
+
+    async def ensure_pci_hotplug(self) -> None:
+        """Verify the live VM exposes the required VFIO control interface."""
+        if not await asyncio.to_thread(self._wait_for_boot):
+            raise CrosvmVMUnavailableError(f"Crosvm VM is unavailable at {self.socket_path}")
+        try:
+            await self.pci_list()
+        except RuntimeError as error:
+            raise RuntimeError(f"Crosvm at {self.socket_path} has no usable VFIO list interface: {error}") from error
 
     async def add_usb_device(self, usb_info: USBInfo, known_port: int | None = None) -> int:
         async with self.usb_locks.setdefault(self.socket_path, asyncio.Lock()):
@@ -287,62 +298,101 @@ class CrosvmLink:
 
     async def add_pci_device(self, _pci_info: PCIInfo) -> None:
         pci_path = self._pci_path(_pci_info)
-        if not self._wait_for_boot():
+        if not await asyncio.to_thread(self._wait_for_boot):
             logger.warning("VM is not booted while adding PCI device %s", pci_path)
 
+        added = False
+        last_error: RuntimeError | None = None
         for attempt in range(self.vm_retry_count + 1):
             try:
                 if pci_path in await self.pci_list():
-                    logger.info("PCI device %s is already attached", pci_path)
+                    if not added:
+                        logger.info("PCI device %s is already attached", pci_path)
                     return
-                await self._run_vfio_command("add", pci_path)
-                if pci_path in await self.pci_list():
-                    return
+                if not added:
+                    await self._run_vfio_command("add", pci_path)
+                    added = True
+                    if pci_path in await self.pci_list():
+                        return
+                last_error = RuntimeError("Crosvm accepted VFIO add but the device did not appear")
             except RuntimeError as error:
+                last_error = error
                 logger.warning("Failed to attach PCI device %s: %s", pci_path, error)
             if attempt < self.vm_retry_count:
                 await asyncio.sleep(self.vm_retry_timeout)
 
-        raise RuntimeError(f"Timed out attaching PCI device {pci_path}")
+        raise RuntimeError(
+            f"Timed out attaching PCI device {pci_path} after {self.vm_retry_count + 1} attempts: {last_error}"
+        ) from last_error
 
     async def remove_pci_device(self, _pci_info: PCIInfo) -> None:
         pci_path = self._pci_path(_pci_info)
+        removed = False
+        last_error: RuntimeError | None = None
         for attempt in range(self.vm_retry_count + 1):
             try:
                 if pci_path not in await self.pci_list():
-                    logger.debug("PCI device %s is already detached", pci_path)
+                    if not removed:
+                        logger.info("PCI device %s is already detached", pci_path)
                     return
-                await self._run_vfio_command("remove", pci_path)
-                if pci_path not in await self.pci_list():
-                    return
+                if not removed:
+                    await self._run_vfio_command("remove", pci_path)
+                    removed = True
+                    if pci_path not in await self.pci_list():
+                        return
+                last_error = RuntimeError("Crosvm accepted VFIO remove but the device is still attached")
             except RuntimeError as error:
+                last_error = error
                 logger.warning("Failed to detach PCI device %s: %s", pci_path, error)
             if attempt < self.vm_retry_count:
                 await asyncio.sleep(self.vm_retry_timeout)
 
-        raise RuntimeError(f"Timed out detaching PCI device {pci_path}")
+        raise RuntimeError(
+            f"Timed out detaching PCI device {pci_path} after {self.vm_retry_count + 1} attempts: {last_error}"
+        ) from last_error
 
     async def pci_list(self) -> list[str]:
         stdout = await self._run_vfio_command("list")
         result = stdout.split()
         if not result or result[0] != "devices":
             raise RuntimeError(f"Malformed Crosvm VFIO list response: {stdout.strip()}")
-        return result[1:]
+        devices = result[1:]
+        unexpected = [
+            entry
+            for entry in devices
+            if re.fullmatch(r"/sys/bus/pci/devices/[0-9A-Fa-f]{4}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}\.[0-7]", entry) is None
+        ]
+        if unexpected:
+            raise RuntimeError(f"Unexpected entries in Crosvm VFIO list response: {unexpected}")
+        return devices
 
     async def is_pci_dev_connected(self, pci_info: PCIInfo) -> bool:
-        return self._pci_path(pci_info) in await self.pci_list()
+        await self.ensure_pci_hotplug()
+        pci_path = self._pci_path(pci_info)
+        last_error: RuntimeError | None = None
+        for attempt in range(self.vm_retry_count + 1):
+            try:
+                return pci_path in await self.pci_list()
+            except RuntimeError as error:
+                last_error = error
+                logger.warning("Failed to query PCI device %s: %s", pci_path, error)
+            if attempt < self.vm_retry_count:
+                await asyncio.sleep(self.vm_retry_timeout)
+        raise RuntimeError(f"Timed out querying PCI device {pci_path}: {last_error}") from last_error
 
     async def wait_until_pci_removed(self, pci_info: PCIInfo) -> None:
         pci_path = self._pci_path(pci_info)
+        last_error: RuntimeError | None = None
         for attempt in range(self.vm_retry_count + 1):
             try:
                 if pci_path not in await self.pci_list():
                     return
             except RuntimeError as error:
+                last_error = error
                 logger.warning("Failed to query PCI device %s during removal: %s", pci_path, error)
             if attempt < self.vm_retry_count:
                 await asyncio.sleep(self.vm_retry_timeout)
-        raise RuntimeError(f"Timed out waiting for PCI device removal: {pci_path}")
+        raise RuntimeError(f"Timed out waiting for PCI device removal {pci_path}: {last_error}") from last_error
 
     async def _run_vfio_command(self, command: str, pci_path: str | None = None) -> str:
         args = [self.crosvm_bin, "vfio", command]
@@ -355,14 +405,24 @@ class CrosvmLink:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
-            stdout_bytes, stderr_bytes = await proc.communicate()
+            try:
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    proc.communicate(), timeout=self.vfio_command_timeout
+                )
+            except TimeoutError as error:
+                proc.kill()
+                await proc.wait()
+                raise RuntimeError(f"Crosvm VFIO {command} timed out on {self.socket_path}") from error
         except OSError as error:
-            raise RuntimeError(f"Failed to execute Crosvm VFIO {command}: {error}") from None
+            raise RuntimeError(f"Failed to execute Crosvm VFIO {command}: {error}") from error
 
-        stdout = stdout_bytes.decode()
-        stderr = stderr_bytes.decode().strip()
+        stdout = stdout_bytes.decode(errors="replace")
+        stderr = stderr_bytes.decode(errors="replace").strip()
         if proc.returncode != 0:
-            raise RuntimeError(f"Crosvm VFIO {command} failed with code {proc.returncode}: {stderr}")
+            raise RuntimeError(
+                f"Crosvm VFIO {command} failed on {self.socket_path} with code {proc.returncode}: "
+                f"{stderr or stdout.strip()}"
+            )
         return stdout
 
     @staticmethod

--- a/vhotplug/device.py
+++ b/vhotplug/device.py
@@ -352,7 +352,7 @@ async def _remove_device_from_vm(
 
     if wait:
         # Wait until the device is no longer in the list
-        await vmm_wait_until_removed(vm, dev_info)
+        await vmm_wait_until_removed(app_context, vm, dev_info)
 
     logger.info("Removed %s", dev_info.friendly_name())
 
@@ -692,7 +692,11 @@ def _get_pci_devices(
 
 
 async def attach_connected_pci(
-    app_context: AppContext, vms_scope: list[str] | None = None, tag: str | None = None
+    app_context: AppContext,
+    vms_scope: list[str] | None = None,
+    tag: str | None = None,
+    *,
+    fail_on_error: bool = False,
 ) -> None:
     """Finds all PCI devices that match the rules from the config and attaches them to VMs."""
     if vms_scope is None:
@@ -711,6 +715,8 @@ async def attach_connected_pci(
     # They are checked and attached atomically in the attach_device function with VM pause/resume
     devices = _get_pci_devices(app_context, disconnected, False)
 
+    failures: list[str] = []
+
     # Attach to VMs
     for device in devices:
         # Get VM details from the config
@@ -719,7 +725,7 @@ async def attach_connected_pci(
         if not vm:
             raise RuntimeError(f"VM {passthrough_info.target_vm} is not found in the config file")
 
-        if vm.get("type") != "qemu":
+        if vm.get("type") not in {"qemu", "crosvm"}:
             continue
 
         if tag and tag != passthrough_info.tag:
@@ -727,8 +733,12 @@ async def attach_connected_pci(
 
         try:
             await attach_device(app_context, passthrough_info, device["pci_info"], False, vms_scope)
-        except RuntimeError:
+        except RuntimeError as error:
             logger.exception("Failed to attach PCI device %s", device["pci_info"].friendly_name())
+            failures.append(f"{device['pci_info'].friendly_name()}: {error}")
+
+    if failures and fail_on_error:
+        raise RuntimeError("Failed to attach PCI devices: " + "; ".join(failures))
 
 
 async def detach_connected_pci(
@@ -812,7 +822,7 @@ async def detach_disconnected_pci(app_context: AppContext, vms_scope: list[str] 
                 vm = app_context.config.get_vm(res.target_vm)
                 if not vm:
                     logger.warning("VM %s not found in the configuration file", res.target_vm)
-                elif await vmm_is_pci_dev_connected(vm, pci_info):
+                elif await vmm_is_pci_dev_connected(app_context, vm, pci_info):
                     logger.info("Detaching %s from %s", pci_info.friendly_name(), res.target_vm)
                     await vmm_remove_device(app_context, vm, pci_info)
             except RuntimeError:
@@ -987,6 +997,9 @@ def get_vmm_args(
 
     if needs_ovmf:
         args = vmm_args_ovmf(vm, app_context.config.get_ovmf_code(), app_context.config.get_ovmf_vars()) + args
+
+    if vm.get("type") == "crosvm" and any(arg == "--vfio" for arg in args):
+        args = ["--vfio-isolate-hotplug", "--pci-hotplug-slots", "1", *args]
 
     # Get ACPI tables for the VM
     for table in app_context.config.get_acpi_tables(vm_name):

--- a/vhotplug/device.py
+++ b/vhotplug/device.py
@@ -9,6 +9,7 @@ import pyudev
 
 from vhotplug.appcontext import AppContext
 from vhotplug.config import PassthroughInfo
+from vhotplug.crosvmlink import CrosvmVMUnavailableError
 from vhotplug.evdev import EvdevInfo, evdev_test_grab, get_evdev_info, is_input_device
 from vhotplug.pci import (
     PCIInfo,
@@ -237,10 +238,7 @@ async def _attach_device_to_vm(app_context: AppContext, dev_info: USBInfo | PCII
     current_vm_name = app_context.dev_state.get_vm_for_device(dev_info)
     if current_vm_name and current_vm_name != vm_name:
         logger.warning("Device is attached to %s, removing...", current_vm_name)
-        try:
-            await remove_device(app_context, dev_info)
-        except RuntimeError as e:
-            logger.warning("Failed to remove: %s", e)
+        await remove_device(app_context, dev_info)
 
     # Setup VFIO for all PCI devices in the IOMMU group if needed
     if isinstance(dev_info, PCIInfo):
@@ -257,7 +255,13 @@ async def _attach_device_to_vm(app_context: AppContext, dev_info: USBInfo | PCII
 
     # Attach device to the VM
     try:
-        await vmm_add_device(app_context, vm, dev_info)
+        vm_socket = vm.get("socket", "")
+        crosvm_usb_port = (
+            app_context.dev_state.get_crosvm_usb_port(dev_info, vm_name, vm_socket)
+            if isinstance(dev_info, USBInfo) and vm.get("type") == "crosvm"
+            else None
+        )
+        attached_port = await vmm_add_device(app_context, vm, dev_info, crosvm_usb_port)
     except Exception:
         if isinstance(dev_info, USBInfo) and app_context.config.usb_authorization_enabled():
             logger.info("Deauthorizing %s", dev_info.friendly_name())
@@ -266,6 +270,8 @@ async def _attach_device_to_vm(app_context: AppContext, dev_info: USBInfo | PCII
 
     # Add selected VM to the state database
     app_context.dev_state.set_vm_for_device(dev_info, vm_name)
+    if isinstance(dev_info, USBInfo) and vm.get("type") == "crosvm":
+        app_context.dev_state.set_crosvm_usb_port(dev_info, vm_name, vm_socket, attached_port)
     app_context.dev_state.clear_disconnected(dev_info)
 
     if app_context.api_server:
@@ -332,7 +338,17 @@ async def _remove_device_from_vm(
 ) -> None:
     """Removes device from VM, saves its state and sends a notification."""
     # Remove from VM
-    await vmm_remove_device(app_context, vm, dev_info)
+    vm_name = vm.get("name", "")
+    vm_socket = vm.get("socket", "")
+    crosvm_usb_port = (
+        app_context.dev_state.get_crosvm_usb_port(dev_info, vm_name, vm_socket)
+        if isinstance(dev_info, USBInfo) and vm.get("type") == "crosvm"
+        else None
+    )
+    try:
+        await vmm_remove_device(app_context, vm, dev_info, crosvm_usb_port)
+    except CrosvmVMUnavailableError as e:
+        logger.warning("VM is unavailable while removing %s: %s", dev_info.friendly_name(), e)
 
     if wait:
         # Wait until the device is no longer in the list

--- a/vhotplug/device.py
+++ b/vhotplug/device.py
@@ -1013,7 +1013,14 @@ def get_vmm_args(
         setup_vfio(pci_info)
 
         # Generate arguments fo the VMM
-        dev_args = vmm_args_pci(vm, pci_info, dev_number, qemu_bus_prefix, passthrough_info.qemu_use_root_bus)
+        dev_args = vmm_args_pci(
+            vm,
+            pci_info,
+            dev_number,
+            qemu_bus_prefix,
+            passthrough_info.qemu_use_root_bus,
+            passthrough_info.crosvm_use_root_bus,
+        )
         dev_number = dev_number + 1
         args.extend(dev_args)
 

--- a/vhotplug/device.py
+++ b/vhotplug/device.py
@@ -38,6 +38,7 @@ from vhotplug.vmm import (
     vmm_args_evdev,
     vmm_args_ovmf,
     vmm_args_pci,
+    vmm_check_pci_hotplug,
     vmm_is_pci_dev_connected,
     vmm_remove_device,
     vmm_wait_until_removed,
@@ -242,6 +243,8 @@ async def _attach_device_to_vm(app_context: AppContext, dev_info: USBInfo | PCII
 
     # Setup VFIO for all PCI devices in the IOMMU group if needed
     if isinstance(dev_info, PCIInfo):
+        # Probe the live Crosvm interface before detaching any host driver.
+        await vmm_check_pci_hotplug(app_context, vm)
         setup_vfio(dev_info)
 
     # Authorize USB device
@@ -266,6 +269,11 @@ async def _attach_device_to_vm(app_context: AppContext, dev_info: USBInfo | PCII
         if isinstance(dev_info, USBInfo) and app_context.config.usb_authorization_enabled():
             logger.info("Deauthorizing %s", dev_info.friendly_name())
             deauthorize_usb_device(dev_info)
+        elif isinstance(dev_info, PCIInfo):
+            logger.exception(
+                "Failed to attach %s; its IOMMU group remains quarantined under vfio-pci and will be retried",
+                dev_info.friendly_name(),
+            )
         raise
 
     # Add selected VM to the state database
@@ -571,7 +579,7 @@ async def attach_existing_pci_device_by_vid_did(
 
 async def attach_existing_pci_devices_by_tag(app_context: AppContext, tag: str) -> None:
     """Find PCI devices by tag and attach to VM."""
-    await attach_connected_pci(app_context, tag=tag)
+    await attach_connected_pci(app_context, tag=tag, fail_on_error=True)
 
 
 async def remove_existing_pci_device(app_context: AppContext, pci_address: str, permanent: bool = False) -> None:
@@ -595,7 +603,7 @@ async def remove_existing_pci_device_by_vid_did(
 
 async def remove_existing_pci_devices_by_tag(app_context: AppContext, tag: str, permanent: bool = False) -> None:
     """Find PCI devices by tag and detach from VM."""
-    await detach_connected_pci(app_context, tag=tag, permanent=permanent)
+    await detach_connected_pci(app_context, tag=tag, permanent=permanent, fail_on_error=True)
 
 
 def _get_pci_devices(
@@ -723,7 +731,8 @@ async def attach_connected_pci(
         passthrough_info = device["passthrough_info"]
         vm = app_context.config.get_vm(passthrough_info.target_vm)
         if not vm:
-            raise RuntimeError(f"VM {passthrough_info.target_vm} is not found in the config file")
+            failures.append(f"VM {passthrough_info.target_vm} is not found in the config file")
+            continue
 
         if vm.get("type") not in {"qemu", "crosvm"}:
             continue
@@ -737,8 +746,11 @@ async def attach_connected_pci(
             logger.exception("Failed to attach PCI device %s", device["pci_info"].friendly_name())
             failures.append(f"{device['pci_info'].friendly_name()}: {error}")
 
-    if failures and fail_on_error:
-        raise RuntimeError("Failed to attach PCI devices: " + "; ".join(failures))
+    if failures:
+        message = "Failed to attach PCI devices: " + "; ".join(failures)
+        logger.error(message)
+        if fail_on_error:
+            raise RuntimeError(message)
 
 
 async def detach_connected_pci(
@@ -747,6 +759,8 @@ async def detach_connected_pci(
     suspend: bool = False,
     tag: str | None = None,
     permanent: bool = False,
+    *,
+    fail_on_error: bool = False,
 ) -> None:
     """Detach all connected PCI devices from VMs."""
     if vms_scope is None:
@@ -756,6 +770,7 @@ async def detach_connected_pci(
     else:
         logger.info("Detaching PCI devices from %s", vms_scope)
 
+    failures: list[str] = []
     for pci_address in app_context.dev_state.list_pci_devices():
         pci_info = pci_info_by_address(app_context, pci_address)
         if pci_info is None:
@@ -787,11 +802,18 @@ async def detach_connected_pci(
 
                 try:
                     await _remove_existing_device(app_context, pci_info, permanent)
-                except RuntimeError:
+                except RuntimeError as error:
                     logger.exception("Failed to remove %s", pci_info.friendly_name())
+                    failures.append(f"{pci_info.friendly_name()}: {error}")
             else:
                 # That's normal for IOMMU group members when pciIommuAddAll is enabled
                 logger.debug("Device %s does not match any rules", pci_info.friendly_name())
+
+    if failures:
+        message = "Failed to detach PCI devices: " + "; ".join(failures)
+        logger.error(message)
+        if fail_on_error:
+            raise RuntimeError(message)
 
 
 async def detach_disconnected_pci(app_context: AppContext, vms_scope: list[str] | None = None) -> None:
@@ -998,8 +1020,10 @@ def get_vmm_args(
     if needs_ovmf:
         args = vmm_args_ovmf(vm, app_context.config.get_ovmf_code(), app_context.config.get_ovmf_vars()) + args
 
-    if vm.get("type") == "crosvm" and any(arg == "--vfio" for arg in args):
-        args = ["--vfio-isolate-hotplug", "--pci-hotplug-slots", "1", *args]
+    if vm.get("type") == "crosvm" and app_context.config.has_pci_passthrough_for_vm(vm_name):
+        # Hot-added VFIO devices only join the virtio-IOMMU when this is set,
+        # including when no matching endpoint was present during VM startup.
+        args = ["--vfio-isolate-hotplug", *args]
 
     # Get ACPI tables for the VM
     for table in app_context.config.get_acpi_tables(vm_name):

--- a/vhotplug/device.py
+++ b/vhotplug/device.py
@@ -987,7 +987,11 @@ async def attach_connected_evdev(app_context: AppContext) -> None:
 
 
 def get_vmm_args(
-    app_context: AppContext, vm_name: str, qemu_bus_prefix: str | None, qemu_bus_start_index: int = 0
+    app_context: AppContext,
+    vm_name: str,
+    qemu_bus_prefix: str | None,
+    qemu_bus_start_index: int = 0,
+    require_pci: bool = False,
 ) -> list[str]:
     """Returns a list of VMM arguments for all devices that match the rules from the config."""
     # Get VM details from the config
@@ -999,11 +1003,13 @@ def get_vmm_args(
     args: list[str] = []
     needs_ovmf = False
     dev_number = qemu_bus_start_index
+    pci_device_count = 0
     for dev in _get_pci_devices(app_context, None, True):
         # Filter by target VM
         passthrough_info = dev["passthrough_info"]
         if passthrough_info.target_vm != vm_name:
             continue
+        pci_device_count += 1
 
         pci_info = dev["pci_info"]
         if passthrough_info.auto_ovmf and pci_is_nvidia_gpu(pci_info):
@@ -1023,6 +1029,12 @@ def get_vmm_args(
         )
         dev_number = dev_number + 1
         args.extend(dev_args)
+
+    if require_pci:
+        if not app_context.config.has_pci_passthrough_for_vm(vm_name):
+            raise RuntimeError(f"No PCI passthrough rules are configured for VM {vm_name}")
+        if pci_device_count == 0:
+            raise RuntimeError(f"PCI passthrough is configured for VM {vm_name}, but no matching devices are present")
 
     if needs_ovmf:
         args = vmm_args_ovmf(vm, app_context.config.get_ovmf_code(), app_context.config.get_ovmf_vars()) + args

--- a/vhotplug/devicestate.py
+++ b/vhotplug/devicestate.py
@@ -1,7 +1,10 @@
+import contextlib
 import json
 import logging
+import os
 import threading
 from pathlib import Path
+from typing import Any
 
 from vhotplug.pci import PCIInfo
 from vhotplug.usb import USBInfo
@@ -16,6 +19,10 @@ class DeviceState:
 
         # Runtime map of USB device_node - VM, used to know from which VM to disconnect
         self.usb_device_vm_map: dict[str, str] = {}
+
+        # Persistent map of USB topology - Crosvm guest binding. A guest port
+        # is valid only for one VM control socket generation.
+        self.crosvm_usb_port_map: dict[str, dict[str, Any]] = {}
 
         # Runtime map of PCI address - VM, used to know from which VM to disconnect
         self.pci_device_vm_map: dict[str, str] = {}
@@ -37,20 +44,80 @@ class DeviceState:
         if self.persistent and self.db_path.exists():
             try:
                 with self.db_path.open("r", encoding="utf-8") as f:
-                    j = json.load(f)
+                    j = self._state_object(json.load(f))
                     self.selected_vms = j.get("selected_vms", {})
                     self.disconnected_devices = set(j.get("disconnected_devices", []))
-            except OSError as e:
-                logger.warning("Failed to load USB state database: %s", e)
+                    ports = j.get("crosvm_usb_ports", {})
+                    if isinstance(ports, dict):
+                        for key, value in ports.items():
+                            if self._valid_crosvm_usb_binding(key, value):
+                                self.crosvm_usb_port_map[key] = value
+                            else:
+                                logger.warning("Discarding invalid Crosvm USB binding for %s", key)
+            except (OSError, TypeError, ValueError) as e:
+                logger.warning("Failed to load state database, starting from empty state: %s", e)
 
     def _save(self) -> None:
         if self.persistent:
-            with self.db_path.open("w", encoding="utf-8") as f:
-                j = {
-                    "selected_vms": self.selected_vms,
-                    "disconnected_devices": list(self.disconnected_devices),
-                }
-                json.dump(j, f, ensure_ascii=False, indent=2)
+            tmp_path = self.db_path.with_name(f".{self.db_path.name}.tmp")
+            try:
+                with tmp_path.open("w", encoding="utf-8") as f:
+                    os.chmod(tmp_path, 0o600)
+                    j = {
+                        "selected_vms": self.selected_vms,
+                        "disconnected_devices": list(self.disconnected_devices),
+                        "crosvm_usb_ports": self.crosvm_usb_port_map,
+                    }
+                    json.dump(j, f, ensure_ascii=False, indent=2)
+                    f.flush()
+                    os.fsync(f.fileno())
+                tmp_path.replace(self.db_path)
+            except OSError as e:
+                logger.warning("Failed to save state database: %s", e)
+                with contextlib.suppress(OSError):
+                    tmp_path.unlink(missing_ok=True)
+
+    @staticmethod
+    def _state_object(value: object) -> dict[str, Any]:
+        if not isinstance(value, dict):
+            raise TypeError("State database root must be an object")
+        return value
+
+    @staticmethod
+    def _valid_port(port: object) -> bool:
+        return type(port) is int and 0 <= port <= 255
+
+    @classmethod
+    def _valid_crosvm_usb_binding(cls, key: object, value: object) -> bool:
+        if not isinstance(key, str) or not isinstance(value, dict):
+            return False
+        return (
+            cls._valid_port(value.get("port"))
+            and isinstance(value.get("vm"), str)
+            and isinstance(value.get("socket_generation"), str)
+            and (value.get("vid") is None or isinstance(value.get("vid"), str))
+            and (value.get("pid") is None or isinstance(value.get("pid"), str))
+            and (value.get("serial") is None or isinstance(value.get("serial"), str))
+        )
+
+    @staticmethod
+    def _usb_key(dev_info: USBInfo) -> str | None:
+        return dev_info.sys_name
+
+    @staticmethod
+    def _socket_generation(socket_path: str) -> str | None:
+        try:
+            stat = os.stat(socket_path)
+        except OSError:
+            return None
+        return f"{stat.st_dev}:{stat.st_ino}:{stat.st_ctime_ns}"
+
+    @staticmethod
+    def _binding_matches_device(binding: dict[str, Any], dev_info: USBInfo) -> bool:
+        return all(
+            actual is None or binding.get(field) == actual
+            for field, actual in (("vid", dev_info.vid), ("pid", dev_info.pid), ("serial", dev_info.serial))
+        )
 
     def set_vm_for_device(self, dev_info: USBInfo | PCIInfo, vm_name: str) -> None:
         with self.lock:
@@ -74,6 +141,10 @@ class DeviceState:
             if isinstance(dev_info, USBInfo):
                 if dev_info.device_node in self.usb_device_vm_map:
                     del self.usb_device_vm_map[dev_info.device_node]
+                key = self._usb_key(dev_info)
+                if key in self.crosvm_usb_port_map:
+                    del self.crosvm_usb_port_map[key]
+                    self._save()
             elif dev_info.address in self.pci_device_vm_map:
                 del self.pci_device_vm_map[dev_info.address]
 
@@ -114,6 +185,69 @@ class DeviceState:
     def list_usb_devices(self) -> dict[str, str]:
         with self.lock:
             return dict(self.usb_device_vm_map)
+
+    def set_crosvm_usb_port(
+        self,
+        dev_info: USBInfo,
+        vm_name: str,
+        socket_path: str,
+        port: int | None,
+    ) -> None:
+        with self.lock:
+            key = self._usb_key(dev_info)
+            if key is None:
+                return
+            if port is None:
+                if self.crosvm_usb_port_map.pop(key, None) is None:
+                    return
+                self._save()
+                return
+            if not self._valid_port(port):
+                raise ValueError(f"Invalid Crosvm USB port: {port}")
+            socket_generation = self._socket_generation(socket_path)
+            if socket_generation is None:
+                logger.warning("Cannot persist Crosvm USB binding: socket %s is unavailable", socket_path)
+                return
+            binding = {
+                "vm": vm_name,
+                "port": port,
+                "socket_generation": socket_generation,
+                "vid": dev_info.vid,
+                "pid": dev_info.pid,
+                "serial": dev_info.serial,
+            }
+            if self.crosvm_usb_port_map.get(key) == binding:
+                return
+            self.crosvm_usb_port_map[key] = binding
+            self._save()
+
+    def get_crosvm_usb_port(self, dev_info: USBInfo, vm_name: str, socket_path: str) -> int | None:
+        with self.lock:
+            key = self._usb_key(dev_info)
+            if key is None:
+                return None
+            binding = self.crosvm_usb_port_map.get(key)
+            if binding is None:
+                return None
+            if (
+                binding.get("vm") != vm_name
+                or binding.get("socket_generation") != self._socket_generation(socket_path)
+                or not self._binding_matches_device(binding, dev_info)
+            ):
+                del self.crosvm_usb_port_map[key]
+                self._save()
+                return None
+            port = binding.get("port")
+            return port if self._valid_port(port) else None
+
+    def clear_crosvm_usb_ports(self, vm_names: list[str]) -> None:
+        with self.lock:
+            keys = [key for key, value in self.crosvm_usb_port_map.items() if value.get("vm") in vm_names]
+            if not keys:
+                return
+            for key in keys:
+                del self.crosvm_usb_port_map[key]
+            self._save()
 
     def list_pci_devices(self) -> dict[str, str]:
         with self.lock:

--- a/vhotplug/vhotplug.py
+++ b/vhotplug/vhotplug.py
@@ -129,6 +129,8 @@ async def monitor_loop(app_context: AppContext, file_watcher: FileWatcher, attac
                     if vm_name:
                         vms_restarted.append(vm_name)
 
+            app_context.dev_state.clear_crosvm_usb_ports(vms_restarted)
+
             # Check non-USB evdev devices for restarted VMs
             await attach_connected_evdev(app_context)
             # Check PCI devices for restarted VMs

--- a/vhotplug/vhotplug.py
+++ b/vhotplug/vhotplug.py
@@ -121,24 +121,31 @@ async def monitor_loop(app_context: AppContext, file_watcher: FileWatcher, attac
         # Detect if any VMs restarted
         vm_restart_detected, sockets_restarted = file_watcher.detect_restart()
         if vm_restart_detected and attach_connected:
-            vms_restarted: list[str] = []
-            for sock in sockets_restarted:
-                vm = app_context.config.get_vm_by_socket(sock)
-                if vm:
-                    vm_name = vm.get("name")
-                    if vm_name:
-                        vms_restarted.append(vm_name)
+            await reattach_devices_for_restarted_vms(app_context, sockets_restarted)
 
-            app_context.dev_state.clear_crosvm_usb_ports(vms_restarted)
 
-            # Check non-USB evdev devices for restarted VMs
-            await attach_connected_evdev(app_context)
-            # Check PCI devices for restarted VMs
-            await attach_connected_pci(app_context, vms_restarted)
-            # Check PCI devices for restarted VMs and detach those that were previously permanently detached
-            await detach_disconnected_pci(app_context, vms_restarted)
-            # Check USB devices for restarted VMs
-            await attach_connected_usb(app_context, vms_restarted)
+async def reattach_devices_for_restarted_vms(app_context: AppContext, sockets_restarted: list[str]) -> None:
+    vms_restarted: list[str] = []
+    for sock in sockets_restarted:
+        vm = app_context.config.get_vm_by_socket(sock)
+        if vm:
+            vm_name = vm.get("name")
+            if vm_name:
+                vms_restarted.append(vm_name)
+
+    # Keep USB port bindings until DeviceState observes a different socket
+    # generation. A socket creation event can already be queued while the
+    # initial device scan waits for the VM to boot; clearing the binding here
+    # would then attach the same physical USB device a second time.
+
+    # Check non-USB evdev devices for restarted VMs
+    await attach_connected_evdev(app_context)
+    # Check PCI devices for restarted VMs
+    await attach_connected_pci(app_context, vms_restarted)
+    # Check PCI devices for restarted VMs and detach those that were previously permanently detached
+    await detach_disconnected_pci(app_context, vms_restarted)
+    # Check USB devices for restarted VMs
+    await attach_connected_usb(app_context, vms_restarted)
 
 
 async def async_main() -> None:

--- a/vhotplug/vmm.py
+++ b/vhotplug/vmm.py
@@ -155,7 +155,12 @@ async def vmm_wait_until_removed(app_context: AppContext, vm: dict[str, Any], de
 
 
 def vmm_args_pci(
-    vm: dict[str, str], dev: PCIInfo, n: int, qemu_bus_prefix: str | None, qemu_use_root_bus: bool = False
+    vm: dict[str, str],
+    dev: PCIInfo,
+    n: int,
+    qemu_bus_prefix: str | None,
+    qemu_use_root_bus: bool = False,
+    crosvm_use_root_bus: bool = False,
 ) -> list[str]:
     vm_type = vm.get("type")
     sys_name = dev.address
@@ -164,7 +169,8 @@ def vmm_args_pci(
         bus = f",bus={qemu_bus_prefix}{n}" if qemu_bus_prefix and not qemu_use_root_bus else ""
         return ["-device", f"vfio-pci,host={sys_name},multifunction=on,id={qemuid}{bus}"]
     if vm_type == "crosvm":
-        return ["--vfio", f"/sys/bus/pci/devices/{sys_name},iommu=viommu,removable=true"]
+        removable = "" if crosvm_use_root_bus else ",removable=true"
+        return ["--vfio", f"/sys/bus/pci/devices/{sys_name},iommu=viommu{removable}"]
     if vm_type == "cloud-hypervisor":
         return ["--device", f"path=/sys/bus/pci/devices/{sys_name}"]
     raise RuntimeError(f"Unsupported vm type: {vm_type}")

--- a/vhotplug/vmm.py
+++ b/vhotplug/vmm.py
@@ -110,7 +110,7 @@ async def vmm_resume(vm: dict[str, str]) -> None:
         await qemu.resume()
 
 
-async def vmm_is_pci_dev_connected(vm: dict[str, str], pci_info: PCIInfo) -> bool:
+async def vmm_is_pci_dev_connected(app_context: AppContext, vm: dict[str, str], pci_info: PCIInfo) -> bool:
     vm_type = vm.get("type")
     vm_socket = vm.get("socket")
     if not vm_socket:
@@ -119,10 +119,13 @@ async def vmm_is_pci_dev_connected(vm: dict[str, str], pci_info: PCIInfo) -> boo
     if vm_type == "qemu":
         qemu = QEMULink(vm_socket)
         return await qemu.is_pci_dev_connected(pci_info)
+    if vm_type == "crosvm":
+        crosvm = CrosvmLink(vm_socket, _get_crosvm_bin(app_context))
+        return await crosvm.is_pci_dev_connected(pci_info)
     return False
 
 
-async def vmm_wait_until_removed(vm: dict[str, Any], dev_info: USBInfo | PCIInfo) -> None:
+async def vmm_wait_until_removed(app_context: AppContext, vm: dict[str, Any], dev_info: USBInfo | PCIInfo) -> None:
     """Waits until the device is removed from the VM."""
     vm_type = vm.get("type")
     vm_socket = vm.get("socket")
@@ -135,6 +138,9 @@ async def vmm_wait_until_removed(vm: dict[str, Any], dev_info: USBInfo | PCIInfo
             await qemu.wait_until_usb_removed(dev_info)
         else:
             await qemu.wait_until_pci_removed(dev_info)
+    elif vm_type == "crosvm" and isinstance(dev_info, PCIInfo):
+        crosvm = CrosvmLink(vm_socket, _get_crosvm_bin(app_context))
+        await crosvm.wait_until_pci_removed(dev_info)
 
 
 def vmm_args_pci(
@@ -147,7 +153,7 @@ def vmm_args_pci(
         bus = f",bus={qemu_bus_prefix}{n}" if qemu_bus_prefix and not qemu_use_root_bus else ""
         return ["-device", f"vfio-pci,host={sys_name},multifunction=on,id={qemuid}{bus}"]
     if vm_type == "crosvm":
-        return ["--vfio", f"/sys/bus/pci/devices/{sys_name},iommu=viommu"]
+        return ["--vfio", f"/sys/bus/pci/devices/{sys_name},iommu=viommu,removable=true"]
     if vm_type == "cloud-hypervisor":
         return ["--device", f"path=/sys/bus/pci/devices/{sys_name}"]
     raise RuntimeError(f"Unsupported vm type: {vm_type}")
@@ -189,7 +195,7 @@ def vmm_args_acpi_table(vm: dict[str, str], acpi_table: str) -> list[str]:
     if vm_type == "qemu":
         return ["-acpitable", f"file={acpi_table}"]
     if vm_type == "crosvm":
-        logger.error("Crosvm doesn't support ACPI table passthrough")
+        return ["--acpi-table", acpi_table]
     if vm_type == "cloud-hypervisor":
         logger.error("Cloud Hypervisor doesn't support ACPI table passthrough")
     raise RuntimeError(f"Unsupported vm type: {vm_type}")

--- a/vhotplug/vmm.py
+++ b/vhotplug/vmm.py
@@ -122,7 +122,18 @@ async def vmm_is_pci_dev_connected(app_context: AppContext, vm: dict[str, str], 
     if vm_type == "crosvm":
         crosvm = CrosvmLink(vm_socket, _get_crosvm_bin(app_context))
         return await crosvm.is_pci_dev_connected(pci_info)
-    return False
+    raise RuntimeError(f"Unsupported vm type: {vm_type}")
+
+
+async def vmm_check_pci_hotplug(app_context: AppContext, vm: dict[str, str]) -> None:
+    """Check Crosvm's live VFIO interface before changing host ownership."""
+    if vm.get("type") != "crosvm":
+        return
+    vm_socket = vm.get("socket")
+    if not vm_socket:
+        raise RuntimeError("No socket path defined")
+    crosvm = CrosvmLink(vm_socket, _get_crosvm_bin(app_context))
+    await crosvm.ensure_pci_hotplug()
 
 
 async def vmm_wait_until_removed(app_context: AppContext, vm: dict[str, Any], dev_info: USBInfo | PCIInfo) -> None:

--- a/vhotplug/vmm.py
+++ b/vhotplug/vmm.py
@@ -17,7 +17,12 @@ def _get_crosvm_bin(app_context: AppContext) -> str | None:
     return crosvm_bin if isinstance(crosvm_bin, str) else None
 
 
-async def vmm_add_device(app_context: AppContext, vm: dict[str, str], dev_info: USBInfo | PCIInfo | EvdevInfo) -> None:
+async def vmm_add_device(
+    app_context: AppContext,
+    vm: dict[str, str],
+    dev_info: USBInfo | PCIInfo | EvdevInfo,
+    crosvm_usb_port: int | None = None,
+) -> int | None:
     """Attaches a device to the VM based on the VMM type and device type."""
     vm_type = vm.get("type")
     vm_socket = vm.get("socket")
@@ -33,19 +38,25 @@ async def vmm_add_device(app_context: AppContext, vm: dict[str, str], dev_info: 
             await qemu.add_pci_device(dev_info)
         else:
             await qemu.add_evdev_device(dev_info)
-    elif vm_type == "crosvm":
+        return None
+    if vm_type == "crosvm":
         crosvm = CrosvmLink(vm_socket, _get_crosvm_bin(app_context))
         if isinstance(dev_info, USBInfo):
-            await crosvm.add_usb_device(dev_info)
-        elif isinstance(dev_info, PCIInfo):
+            return await crosvm.add_usb_device(dev_info, crosvm_usb_port)
+        if isinstance(dev_info, PCIInfo):
             await crosvm.add_pci_device(dev_info)
         else:
             raise RuntimeError(f"Evdev passthrough is not supported by {vm_type}")
-    else:
-        raise RuntimeError(f"Unknown VM type: {vm_type}")
+        return None
+    raise RuntimeError(f"Unknown VM type: {vm_type}")
 
 
-async def vmm_remove_device(app_context: AppContext, vm: dict[str, Any], dev_info: USBInfo | PCIInfo) -> None:
+async def vmm_remove_device(
+    app_context: AppContext,
+    vm: dict[str, Any],
+    dev_info: USBInfo | PCIInfo,
+    crosvm_usb_port: int | None = None,
+) -> None:
     """Removes a device from the VM based on the VMM type and device type."""
     vm_type = vm.get("type")
     vm_socket = vm.get("socket")
@@ -68,7 +79,7 @@ async def vmm_remove_device(app_context: AppContext, vm: dict[str, Any], dev_inf
         # Crosvm seems to automatically remove the device from the list so this code is not really used
         crosvm = CrosvmLink(vm_socket, _get_crosvm_bin(app_context))
         if isinstance(dev_info, USBInfo):
-            await crosvm.remove_usb_device(dev_info)
+            await crosvm.remove_usb_device(dev_info, crosvm_usb_port)
         else:
             await crosvm.remove_pci_device(dev_info)
     else:

--- a/vhotplugcli/apiclient.py
+++ b/vhotplugcli/apiclient.py
@@ -160,13 +160,20 @@ class APIClient:
     def pci_resume(self, vm: str) -> dict[str, Any]:
         return self.send({"action": "pci_resume", "vm": vm})
 
-    def vmm_args(self, vm: str, qemu_bus_prefix: str | None, qemu_bus_start_index: int | None) -> dict[str, Any]:
+    def vmm_args(
+        self,
+        vm: str,
+        qemu_bus_prefix: str | None,
+        qemu_bus_start_index: int | None,
+        require_pci: bool = False,
+    ) -> dict[str, Any]:
         return self.send(
             {
                 "action": "vmm_args",
                 "vm": vm,
                 "qemu_bus_prefix": qemu_bus_prefix,
                 "qemu_bus_start_index": qemu_bus_start_index,
+                "require_pci": require_pci,
             }
         )
 

--- a/vhotplugcli/vhotplugcli.py
+++ b/vhotplugcli/vhotplugcli.py
@@ -208,6 +208,8 @@ def vmm_args(
         if res.get("result") == "failed":
             raise RuntimeError(f"Failed to get VMM args for PCI devices: {res.get('error')}")
         args = res.get("vmm_args", [])
+        if any(any(char.isspace() for char in arg) for arg in args):
+            raise RuntimeError("VMM arguments containing whitespace are not supported")
         cmdline = " ".join(args)
         logger.info("Resolved %d VMM argument(s) for %s: %s", len(args), vm, cmdline or "<none>")
         print(cmdline, end="")

--- a/vhotplugcli/vhotplugcli.py
+++ b/vhotplugcli/vhotplugcli.py
@@ -181,20 +181,35 @@ def pci_resume(client: APIClient, vm: str) -> None:
     logger.info("Successfully resumed")
 
 
-def vmm_args(client: APIClient, vm: str, qemu_bus_prefix: str | None, qemu_bus_start_index: int | None) -> None:
+def vmm_args(
+    client: APIClient,
+    vm: str,
+    qemu_bus_prefix: str | None,
+    qemu_bus_start_index: int | None,
+    timeout: float,
+    require_pci: bool,
+) -> None:
+    if timeout < 0:
+        raise ValueError("VMM argument timeout must not be negative")
+
+    deadline = time.monotonic() + timeout
     while True:
         try:
             client.connect()
-            res = client.vmm_args(vm, qemu_bus_prefix, qemu_bus_start_index)
+            res = client.vmm_args(vm, qemu_bus_prefix, qemu_bus_start_index, require_pci)
         except RuntimeError as e:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise RuntimeError(f"Timed out waiting for vhotplug while resolving VMM args for {vm}: {e}") from e
             logger.warning(str(e))
-            time.sleep(1)
+            time.sleep(min(1, remaining))
             continue
 
         if res.get("result") == "failed":
             raise RuntimeError(f"Failed to get VMM args for PCI devices: {res.get('error')}")
         args = res.get("vmm_args", [])
         cmdline = " ".join(args)
+        logger.info("Resolved %d VMM argument(s) for %s: %s", len(args), vm, cmdline or "<none>")
         print(cmdline, end="")
         break
 
@@ -335,7 +350,27 @@ def main() -> int:
     vmm_args_parser.add_argument("--vm", help="Virtual machine name")
     vmm_args_parser.add_argument("--qemu-bus-prefix", help="QEMU Bus Prefix")
     vmm_args_parser.add_argument("--qemu-bus-start-index", type=int, help="QEMU Bus Start Index")
-    vmm_args_parser.set_defaults(func=lambda a, c: vmm_args(c, a.vm, a.qemu_bus_prefix, a.qemu_bus_start_index))
+    vmm_args_parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30,
+        help="Maximum seconds to wait for the vhotplug daemon (default: 30)",
+    )
+    vmm_args_parser.add_argument(
+        "--require-pci",
+        action="store_true",
+        help="Fail unless at least one configured PCI device is present",
+    )
+    vmm_args_parser.set_defaults(
+        func=lambda a, c: vmm_args(
+            c,
+            a.vm,
+            a.qemu_bus_prefix,
+            a.qemu_bus_start_index,
+            a.timeout,
+            a.require_pci,
+        )
+    )
 
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary

- implement Crosvm PCI add, remove, list, connected-state, and removal waits
- reconcile state with `crosvm vfio list` after daemon or VM restarts
- retry transient hotplug states with bounded errors
- preserve IOMMU groups and generate Crosvm VFIO, slot, and ACPI arguments
- restore PCI devices across suspend and resume

## Validation

- pytest: 41 passed
- treefmt, Ruff, and configured mypy checks passed
- live x86 laptop: NetVM and AudioVM groups detached and reattached across suspend/resume

## Dependencies

Contains the commit from #21 and should be rebased onto `master` after #21 merges.
