### PR TITLE
Fix crash in _modalias() when USB device attributes are transiently None

### DIFF
--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -1,0 +1,50 @@
+from vhotplug.usb import USBInfo
+
+
+def test_get_modaliases_full_info() -> None:
+    info = USBInfo(
+        vid="413c",
+        pid="81e0",
+        device_class=0,
+        device_subclass=0,
+        device_protocol=0,
+        bcd_device=0x0100,
+        interfaces=":030101:",
+    )
+    aliases = info.get_modaliases()
+    assert aliases == ["usb:v413Cp81E0d0100dc00dsc00dp00ic03isc01ip01in00"]
+
+
+def test_get_modaliases_missing_bcd_device() -> None:
+    # Reproduces a real crash: a device re-enumerating during a host resume can
+    # report bcdDevice as unavailable, leaving USBInfo.bcd_device as None. Before
+    # the fix, get_modaliases() -> _modalias() raised
+    # TypeError: unsupported format string passed to NoneType.__format__
+    info = USBInfo(
+        vid="413c",
+        pid="81e0",
+        device_class=0,
+        device_subclass=0,
+        device_protocol=0,
+        bcd_device=None,
+        interfaces=":030101:",
+    )
+    assert info.get_modaliases() == []
+
+
+def test_get_modaliases_missing_device_class() -> None:
+    info = USBInfo(
+        vid="413c",
+        pid="81e0",
+        device_class=None,
+        device_subclass=0,
+        device_protocol=0,
+        bcd_device=0x0100,
+        interfaces=":030101:",
+    )
+    assert info.get_modaliases() == []
+
+
+def test_get_modaliases_no_vid_pid() -> None:
+    info = USBInfo(interfaces=":030101:")
+    assert info.get_modaliases() == []

--- a/vhotplug/usb.py
+++ b/vhotplug/usb.py
@@ -120,7 +120,18 @@ class USBInfo(NamedTuple):
         return False
 
     def _modalias(self, iface_class: int, iface_subclass: int, iface_protocol: int, iface_number: int) -> str | None:
-        if self.vid and self.pid:
+        # bcd_device/device_class/device_subclass/device_protocol come from udev
+        # attributes that can be transiently absent (e.g. a device still settling
+        # after a host resume), so all four must be checked -- not just vid/pid --
+        # or formatting a None with :02X/:04X raises TypeError and crashes vhotplug.
+        if (
+            self.vid
+            and self.pid
+            and self.bcd_device is not None
+            and self.device_class is not None
+            and self.device_subclass is not None
+            and self.device_protocol is not None
+        ):
             return (
                 f"usb:v{self.vid.upper()}p{self.pid.upper()}"
                 f"d{self.bcd_device:04X}"


### PR DESCRIPTION
## Summary
- `USBInfo.bcd_device`, `device_class`, `device_subclass` and `device_protocol` are all typed `int | None`, but `_modalias()` only checked `vid`/`pid` before formatting all four as hex, raising `TypeError: unsupported format string passed to NoneType.__format__`.
- `bcd_device` in particular comes from the `bcdDevice` udev attribute, which can be transiently unavailable while a device is still settling. Found in practice: a Dell WWAN device re-enumerating during a host resume from suspend crashed `vhotplug.service` (systemd auto-restarted it, so it never showed up as a failed unit — only visible by reading the journal directly).
- Fix: guard on all four fields being non-`None`, consistent with `_modalias()`'s existing return-`None`-on-insufficient-info pattern for `vid`/`pid`.
- Note for maintainers: this project's strict `mypy` config does not catch this pattern — f-string hex format specs (`:02X`/`:04X`) aren't checked against `Optional` types, which is presumably how it shipped unnoticed.

Found while investigating an unrelated suspend/resume behavior on a Ghaf dell-7330 device. **This crash is confirmed real and reproducible, but not confirmed as the cause of that other issue** — it occurred at 2 of 3 observed resumes, including one that was followed by an otherwise-normal cycle. Reporting it as a genuine bug on its own merits regardless.

## Test plan
- [x] Added `tests/test_usb.py`: a happy-path case, two cases reproducing the crash (missing `bcd_device`, missing `device_class`), and a no-`vid`/`pid` case
- [x] Reverted the fix locally and confirmed the new tests fail with the exact production error (`TypeError: unsupported format string passed to NoneType.__format__`), then restored it
- [x] Full suite: `python -m pytest` — 31/31 passing
- [x] `treefmt --fail-on-change` — 0 changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)