### PR TITLE
fix(pci): wait for vfio device node before returning from bind

### DIFF
--- a/tests/test_pci.py
+++ b/tests/test_pci.py
@@ -1,0 +1,55 @@
+import time
+from pathlib import Path
+
+import pytest
+
+from vhotplug import pci
+
+
+def test_wait_for_vfio_device_node_retries_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Reproduces a real race: writing to drivers_probe schedules vfio-pci's probe
+    # but does not guarantee it has finished, so /dev/vfio/<group> can briefly not
+    # exist yet. The caller (VM start) must wait for it rather than assume it is
+    # there as soon as drivers_probe has been written.
+    attempts = 0
+
+    def fake_exists(self: Path) -> bool:
+        nonlocal attempts
+        if self.name == "iommu_group":
+            return True
+        attempts += 1
+        return attempts == 2
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    monkeypatch.setattr(Path, "resolve", lambda _self: Path("/sys/kernel/iommu_groups/7"))
+    sleep_intervals: list[float] = []
+    monkeypatch.setattr(time, "sleep", sleep_intervals.append)
+
+    pci._wait_for_vfio_device_node("0000:00:02.0")
+
+    assert attempts == 2
+    assert sleep_intervals == [0.1]
+
+
+def test_wait_for_vfio_device_node_gives_up_after_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_exists(self: Path) -> bool:
+        # iommu_group is present; /dev/vfio/<group> never appears.
+        return self.name == "iommu_group"
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    monkeypatch.setattr(Path, "resolve", lambda _self: Path("/sys/kernel/iommu_groups/7"))
+    sleep_intervals: list[float] = []
+    monkeypatch.setattr(time, "sleep", sleep_intervals.append)
+
+    pci._wait_for_vfio_device_node("0000:00:02.0")
+
+    assert sleep_intervals == [0.1, 0.1, 0.1, 0.1]
+
+
+def test_wait_for_vfio_device_node_returns_immediately_when_iommu_group_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(Path, "exists", lambda _self: False)
+    monkeypatch.setattr(time, "sleep", lambda _seconds: pytest.fail("Unexpected sleep"))
+
+    pci._wait_for_vfio_device_node("0000:00:02.0")

--- a/vhotplug/pci.py
+++ b/vhotplug/pci.py
@@ -141,6 +141,30 @@ def _unbind_driver(pci_address: str) -> None:
         logger.debug("Device %s has no driver assigned", pci_address)
 
 
+def _wait_for_vfio_device_node(pci_address: str) -> None:
+    """Waits for the vfio group device node to appear after binding.
+
+    Writing to drivers_probe schedules the driver's probe callback but does not
+    guarantee it has completed, so /dev/vfio/<group> may not exist yet when this
+    returns. Callers (VM start/hotplug) that open the node immediately afterwards
+    can otherwise race a still-running vfio-pci probe.
+    """
+    iommu_group = Path(f"/sys/bus/pci/devices/{pci_address}/iommu_group")
+    if not iommu_group.exists():
+        logger.warning("IOMMU group does not exist for %s", pci_address)
+        return
+
+    group_number = iommu_group.resolve().name
+    vfio_device = Path(f"/dev/vfio/{group_number}")
+    for _ in range(1, 5):
+        if vfio_device.exists():
+            logger.debug("VFIO device node %s is ready", vfio_device)
+            return
+        logger.warning("VFIO device node %s does not exist yet", vfio_device)
+        time.sleep(0.1)
+    logger.error("VFIO device node %s did not appear for %s", vfio_device, pci_address)
+
+
 def _bind_vfio_pci(pci_address: str) -> None:
     """Checks the driver assigned for the device and changes it to vfio-pci."""
     device_path = f"/sys/bus/pci/devices/{pci_address}"
@@ -161,6 +185,8 @@ def _bind_vfio_pci(pci_address: str) -> None:
 
     with open("/sys/bus/pci/drivers_probe", "w", encoding="utf-8") as f:
         f.write(pci_address)
+
+    _wait_for_vfio_device_node(pci_address)
 
     logger.debug("Successfully bound vfio-pci driver for %s", pci_address)
 


### PR DESCRIPTION
## Summary
- `_bind_vfio_pci()` writes `driver_override` and `drivers_probe` then returns immediately, assuming the bind is complete. `vfio-pci`'s probe can run asynchronously, so `/dev/vfio/<group>` may not exist yet — callers (VM start, hotplug) that open it right after can lose the race.
- Adds `_wait_for_vfio_device_node()`, mirroring the existing poll-and-retry `get_iommu_group_devices()` already does for `iommu_group`, but for the vfio group device node. Called at the end of `_bind_vfio_pci()`.

## Observed on real hardware
Booting a darter-pro with GPU passthrough to `gui-vm`:
```
vhotplug: Attaching 0000:00:02.0 ... to gui-vm
microvm@gui-vm: -device vfio-pci,host=0000:00:02.0,...: vfio 0000:00:02.0: Could not open '/dev/vfio/0': No such file or directory
```
Both lines land in the same second. `systemd`'s restart-on-failure retried `microvm@gui-vm.service` 5s later and it succeeded, masking the race rather than fixing it.

## Test plan
- [x] `ruff check` / `ruff format --check` clean on changed files
- [x] `python -m pytest` — new tests pass, full suite (36 tests) passes with no regressions
- [x] Checked for duplicates: no existing open issue/PR covers this; the most recent related fix (`4d3c37c1`, "Fix VM socket readiness race") addresses a different race (QMP socket readiness for USB hotplug-during-boot), not this one